### PR TITLE
[WIP] C bindings issues.

### DIFF
--- a/src/swresample_stubs.c
+++ b/src/swresample_stubs.c
@@ -352,8 +352,10 @@ static int convert_to_planar_float_array(swr_t *swr, uint8_t **in_data, int in_n
 
   swr->out_size = ret;
 
+  if (ret != out_nb_samples)
+    alloc_out_planar_float_array(swr, ret);
+
   for (i = 0; i < swr->out_nb_channels; i++) {
-    Store_field(swr->out_vector, i, caml_alloc(ret * Double_wosize, Double_array_tag));
     pcm = (double *)out_data[i];
     for (j = 0; j < ret; j++)
       Store_double_field(Field(swr->out_vector, i), j, pcm[j]);

--- a/test/swresample.ml
+++ b/test/swresample.ml
@@ -4,6 +4,7 @@ open Channel_layout
 open Sample_format
 
 module R = Swresample.Make (Swresample.FloatArray) (Swresample.S32Bytes)
+
 module R0 = Swresample.Make (Swresample.FloatArray) (Swresample.S16Frame)
 module R1 = Swresample.Make (Swresample.Frame) (Swresample.U8BigArray)
 module R2 = Swresample.Make (Swresample.U8BigArray) (Swresample.DblPlanarFrame)
@@ -14,11 +15,12 @@ module R6 = Swresample.Make (Swresample.PlanarFloatArray) (Swresample.S32Frame)
 module R7 = Swresample.Make (Swresample.S32Frame) (Swresample.FloatArray)
 module R8 = Swresample.Make (Swresample.FloatArray) (Swresample.S32BigArray)
 module R9 = Swresample.Make (Swresample.S32BigArray) (Swresample.S32Bytes)
+module R10 = Swresample.Make (Swresample.S32Bytes) (Swresample.S32Bytes)
 
 module ConverterInput = FFmpeg.Swresample.Make(FFmpeg.Swresample.Frame)
 module Converter = ConverterInput(FFmpeg.Swresample.PlanarFloatArray)
 
-let logStep step v = (* /* Gc.full_major (); Printf.printf"%s done\n%!" step; */ *) v
+let logStep step v = Gc.full_major (); Printf.printf"%s done\n%!" step; v
 
 let foi = float_of_int
 let pi = 4.0 *. atan 1.0
@@ -30,6 +32,7 @@ let test() =
   let r = R.create CL_mono rate CL_stereo 44100 in
 
   let dst2 = open_out_bin "test_swresample_out2.raw" in
+
   let r0 = R0.create CL_mono rate CL_5point1 96000 in
   let r1 = R1.create CL_5point1 ~in_sample_format:SF_S16 96000 CL_stereo 16000 in
   let r2 = R2.create CL_stereo 16000 CL_surround 44100 in
@@ -40,6 +43,8 @@ let test() =
   let r7 = R7.create CL_stereo 44100 CL_stereo 48000 in
   let r8 = R8.create CL_stereo 48000 CL_stereo 96000 in
   let r9 = R9.create CL_stereo 96000 CL_stereo 44100 in
+  let r10 = R10.create CL_stereo 44100 CL_mono 44100 in
+
   logStep"R.create"();
 
   for note = 0 to 95 do
@@ -47,10 +52,10 @@ let test() =
     let freq = 55. *. (2. ** ((foi note) /. 12.)) in
     let len = int_of_float((frate /. freq) *. (floor(freq /. 4.))) in
     let c = (2. *. pi *. freq) /. frate in
-    let src = Array.init len (fun t -> sin(foi t *. c)) |> logStep"src" in
+    let src = Array.init len (fun t -> sin(foi t *. c)) |> logStep("src of len "^ string_of_int len) in
 
     src |> R.convert r |> logStep"convert r" |> output_bytes dst1 |> logStep"output_bytes dst1";
-
+    
     src
     |> R0.convert r0 |> logStep"convert r0"
     |> R1.convert r1 |> logStep"convert r1"
@@ -62,8 +67,10 @@ let test() =
     |> R7.convert r7 |> logStep"convert r7"
     |> R8.convert r8 |> logStep"convert r8"
     |> R9.convert r9 |> logStep"convert r9"
-    |> output_bytes dst2 |> logStep"output_bytes dst2"
-    |> logStep("note " ^ string_of_int note)
+    |> R10.convert r10 |> logStep"convert r10"
+    |> output_bytes dst2 |> logStep"output_bytes dst2";
+
+    logStep("note " ^ string_of_int note) ();
   done;
 
   close_out dst1 |> logStep"close_out dst1";

--- a/test/swresample.ml
+++ b/test/swresample.ml
@@ -112,4 +112,6 @@ let test() =
         close_out audio_output_file;
 
       with _ -> print_endline("No audio stream in "^url)
-    )
+    );
+
+  Gc.full_major (); Gc.full_major (); 


### PR DESCRIPTION
I've noticed a couple of issues in the way C bindings are written. This PR contains an example of how to do it properly in one function. Here are the notes:

* `double` array are special arrays and, with some architectures, will be actual `C` double-aligned arrays. However, it is not guaranteed so you will need to call `Double_field` and `Store_double_field` and cannot use `memcpy`, unfortunately.
* Each time that you execute a `C` operation that can be blocking, it is important to release the `OCaml` global lock. This is done by ensuring that all the data passed to the `C` call is allocated outside of the `OCaml` stack and by wrapping the `C` call between `caml_release_runtime_system()/caml_acquire_runtime_system()`

This PR examplifies how to do it in a single function. It still does not fix the issue mentioned in #1 about float decoding corruption.