### PR TITLE
Enable cross-compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AC_MSG_RESULT([configuring $PACKAGE_STRING])
 
 AC_BASE_CHECKS()
 
+AC_PATH_PROG(SYSTEM_OCAMLOPT,"ocamlopt")
+AC_SUBST(SYSTEM_OCAMLOPT)
+
 PKG_PROG_PKG_CONFIG()
 PKG_CONFIG_CHECK_MODULE([libavutil])
 PKG_CONFIG_CHECK_MODULE([libswscale])
@@ -13,6 +16,10 @@ PKG_CONFIG_CHECK_MODULE([libavformat])
 PKG_CONFIG_CHECK_MODULE([libavcodec])
 #PKG_CONFIG_CHECK_MODULE([libswresample])
 #PKG_CONFIG_CHECK_MODULE([libavdevice])
+
+# Do we need more?
+GEN_CODE_INCLUDE=`$PKG_CONFIG --variable=includedir libavcodec`
+AC_SUBST(GEN_CODE_INCLUDE)
 
 AC_CHECK_DECL([avcodec_send_packet],[HAS_AV="yes"],[HAS_AV=""],[#include "libavcodec/avcodec.h"])
 AC_SUBST(HAS_AV)
@@ -22,6 +29,7 @@ if test "x$HAS_SWRESAMPLE" = "xyes" ; then
   LIBS="$LIBS -lswresample"
 fi
 AC_SUBST(HAS_SWRESAMPLE)
+
 
 AC_CHECK_HEADERS([libavdevice/avdevice.h],[HAS_AVDEVICE="yes"],[HAS_AVDEVICE=""])
 if test "x$HAS_AVDEVICE" = "xyes" ; then

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -10,6 +10,7 @@ OCAMLMAKEFILE = OCamlMakefile
 OCAMLFIND = @OCAMLFIND@
 OCAMLFIND_LDCONF = @OCAMLFIND_LDCONF@
 OCAMLC = @OCAMLC@ -thread
+SYSTEM_OCAMLOPT = @SYSTEM_OCAMLOPT@
 OCAMLOPT = @OCAMLOPT@ -thread
 OCAMLBEST = @OCAMLBEST@
 OCAMLMKTOP = @OCAMLMKTOP@
@@ -24,6 +25,8 @@ LATEX = @LATEX@
 DVIPS = @DVIPS@
 PS2PDF = @PS2PDF@
 OCAMLLIBPATH = @CAMLLIBPATH@
+
+GEN_CODE_INCLUDE = @GEN_CODE_INCLUDE@
 
 SOURCES = pixel_format.mli pixel_format.ml channel_layout.mli channel_layout.ml sample_format.mli sample_format.ml avutil_stubs.h avutil_stubs.c avutil.mli avutil.ml swscale_stubs.c swscale.mli swscale.ml
 ifeq "@HAS_AV@" "yes"
@@ -59,9 +62,9 @@ byte: byte-code-library
 opt: native-code-library
 
 gen-code:
-	$(OCAMLOPT) -c gen_code_stubs.c
-	$(OCAMLOPT) str.cmxa gen_code_stubs.o gen_code.ml -o gen_code
-	./gen_code $(INCDIRS) $(CFLAGS)
+	$(SYSTEM_OCAMLOPT) -c gen_code_stubs.c
+	$(SYSTEM_OCAMLOPT) str.cmxa gen_code_stubs.o gen_code.ml -o gen_code
+	./gen_code -I$(GEN_CODE_INCLUDE)
 
 install: libinstall
 


### PR DESCRIPTION
This PR makes it possible to cross-compile `ocaml-ffmpeg` by making sure that `gen-code` is compiled using the native compiler and aware of the target hosts headers location for `ffmpeg`.