### PR TITLE
Fix decoding logic.

### DIFF
--- a/examples/decode_stream/decode_stream.ml
+++ b/examples/decode_stream/decode_stream.ml
@@ -25,11 +25,15 @@ let () =
     Av.find_best_audio_stream container
   in
   let rec f () =
-    match Av.read_frame stream with
-      | `Frame frame ->
-           Av.write_frame out_stream frame;
-           f ()
-      | `End_of_file -> ()
+    try
+      match Av.read_frame stream with
+        | `Frame frame ->
+             Av.write_frame out_stream frame;
+             f ()
+        | `End_of_file -> ()
+    with
+      | FFmpeg.Avutil.Failure s when s = "Failed to read stream : Invalid data found when processing input" ->
+          f ()
   in
   f ();
 

--- a/src/gen_code.ml
+++ b/src/gen_code.ml
@@ -117,7 +117,7 @@ let () =
 
   List.iter(print_define_polymorphic_variant_value pvv_oc)
     ["Audio"; "Video"; "Subtitle"; "Packet"; "Frame";
-     "Ok"; "Again"; "End_of_file"; "Error";
+     "Ok"; "Again"; "End_of_file";
      "Second"; "Millisecond"; "Microsecond"; "Nanosecond"];
 
   close_out pvv_oc;


### PR DESCRIPTION
While working with a weird format, I realized some issues with the decoding logic. In this format, every now and then, a bad frame pops out, which `ffmpeg` is able to ignore and keep decoding just fine. 

On the other hand, with the binding, ignoring these frames resulted in chopped output. The reason being that, for each paquet submitted to the decoder, there can be multiple resulting frame. However, currently, the decoder code keeps parity between consumed paquets and decoded frame.

This PR fixes that logic, while cleaning up a little bit around. I'm gonna be testing it, let me know what you think.

Next, I would like to also cleanup the exception logic so that the application is able to catch the right exception (`AVERROR_INVALIDDATA`). I have a PR pending but it's not ready to merge yet.