### PR TITLE
Library errors && cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Makefile
+/Makefile
 aclocal.m4
 autom4te.cache/
 config.guess
@@ -36,3 +36,14 @@ src/swresample_options.ml
 src/swresample_options.mli
 src/swresample_options_stubs.h
 examples/decode_stream/decode_stream
+examples/audio_decoding/audio_decoding
+examples/audio_device/audio_device
+examples/decode_audio/decode_audio
+examples/demuxing_decoding/demuxing_decoding
+examples/encode_audio/encode_audio
+examples/encode_video/encode_video
+examples/encoding/encoding
+examples/player/player
+examples/remuxing/remuxing
+examples/transcode_aac/transcode_aac
+examples/transcoding/transcoding

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,12 @@ examples/player/player
 examples/remuxing/remuxing
 examples/transcode_aac/transcode_aac
 examples/transcoding/transcoding
+examples/audio_decoding/flac.raw
+examples/remuxing/out.mp4
+*.mp3
+*.flac
+*.ogg
+*.mp2
+*.mkv
+*.mp4
+*.raw

--- a/Makefile.in
+++ b/Makefile.in
@@ -28,7 +28,7 @@ dist:
 	tar zcvf ../$(PROGNAME)-$(VERSION).tar.gz $(PROGNAME)-$(VERSION)
 	rm -rf $(PROGNAME)-$(VERSION)
 
-test: all
+test: distclean all
 	$(MAKE) -C examples $@
 	$(MAKE) -C test $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ocaml-ffmpeg],[0.2.1],[savonet-users@lists.sourceforge.net])
+AC_INIT([ocaml-ffmpeg],[0.3.0],[savonet-users@lists.sourceforge.net])
 
 VERSION=$PACKAGE_VERSION
 requires="bigarray threads"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,6 +11,7 @@ test: all
 	$(MAKE) -C encode_video $@
 	$(MAKE) -C encoding $@
 	$(MAKE) -C decode_audio $@
+	$(MAKE) -C decode_stream $@
 	$(MAKE) -C audio_decoding $@
 	$(MAKE) -C audio_device $@
 	$(MAKE) -C remuxing $@

--- a/examples/audio_decoding/Makefile
+++ b/examples/audio_decoding/Makefile
@@ -6,7 +6,7 @@ INCDIRS = ../../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: dc
+all: nc
 
 test: all
 	./audio_decoding ../decode_audio/A4.ogg A4

--- a/examples/audio_device/audio_device.ml
+++ b/examples/audio_device/audio_device.ml
@@ -15,14 +15,14 @@ let () =
   Avutil.Log.set_callback print_string;
   
   let src = try Avdevice.open_audio_input Sys.argv.(1)
-    with Avutil.Failure _ -> Av.open_input Sys.argv.(1) in
+    with Avutil.Error _ -> Av.open_input Sys.argv.(1) in
 
   let (_, ias, _) = Av.find_best_audio_stream src in
 
   let dst = try
       if Array.length Sys.argv < 3 then Avdevice.open_default_audio_output()
        else Avdevice.open_audio_output Sys.argv.(2)
-    with Avutil.Failure _ ->
+    with Avutil.Error _ ->
       Av.open_output Sys.argv.(2)
       |> Av.new_audio_stream ~codec_id:`Flac |> Av.get_output in
 
@@ -32,7 +32,7 @@ let () =
       | _ -> print_endline "Unexpected dev to app controle message")) dst;
 
   (try Avdevice.App_to_dev.(control_messages[Get_volume; Set_volume 0.3]) dst
-   with Avutil.Failure msg -> prerr_endline msg);
+   with Avutil.Error err -> prerr_endline (Avutil.string_of_error err));
 
   let rec run n =
     if n > 0 then match Av.read_frame ias with

--- a/examples/audio_device/audio_device.ml
+++ b/examples/audio_device/audio_device.ml
@@ -1,6 +1,9 @@
 open FFmpeg
 
 let () =
+  Printexc.record_backtrace true
+
+let () =
   if Array.length Sys.argv < 2 then Printf.(Av.Format.(
       printf "\ninput devices :\n";
       Avdevice.get_audio_input_formats() |> List.iter
@@ -35,9 +38,11 @@ let () =
    with Avutil.Error err -> prerr_endline (Avutil.string_of_error err));
 
   let rec run n =
-    if n > 0 then match Av.read_frame ias with
-      | `Frame frame -> Av.write_audio_frame dst frame; run(n - 1)
-      | `End_of_file -> ()
+    if n > 0 then try
+      let frame = Av.read_frame ias in
+      Av.write_audio_frame dst frame; run(n - 1)
+    with
+      | Avutil.Error `Eof -> ()
   in
   run 500;
 

--- a/examples/decode_audio/decode_audio.ml
+++ b/examples/decode_audio/decode_audio.ml
@@ -2,6 +2,9 @@ open FFmpeg
 open Avcodec
 
 let () =
+  Printexc.record_backtrace true
+
+let () =
   if Array.length Sys.argv < 5 then (
     Printf.eprintf "      usage: %s <input file> <input codec> <output file> <output codec>
       API example program to show how to read audio frames from an input file.
@@ -22,7 +25,6 @@ let () =
   let out_file = Av.open_output Sys.argv.(3) in
   let out_stream = Av.new_audio_stream ~codec_name:Sys.argv.(4) out_file in
 
-  (* Unix.map_file in_fd Bigarray.Int8_unsigned Bigarray.c_layout false [|-1|] *)
   Unix.map_file in_fd Bigarray.Int8_unsigned Bigarray.c_layout false [|-1|]
   |> Bigarray.array1_of_genarray
   |> Packet.parse_data parser @@ Avcodec.decode decoder @@ Av.write_frame out_stream;

--- a/examples/decode_audio/decode_audio.ml
+++ b/examples/decode_audio/decode_audio.ml
@@ -23,7 +23,7 @@ let () =
   let out_stream = Av.new_audio_stream ~codec_name:Sys.argv.(4) out_file in
 
   (* Unix.map_file in_fd Bigarray.Int8_unsigned Bigarray.c_layout false [|-1|] *)
-  Bigarray.Genarray.map_file in_fd Bigarray.Int8_unsigned Bigarray.c_layout false [|-1|]
+  Unix.map_file in_fd Bigarray.Int8_unsigned Bigarray.c_layout false [|-1|]
   |> Bigarray.array1_of_genarray
   |> Packet.parse_data parser @@ Avcodec.decode decoder @@ Av.write_frame out_stream;
 

--- a/examples/decode_stream/Makefile
+++ b/examples/decode_stream/Makefile
@@ -1,0 +1,17 @@
+SOURCES = decode_stream.ml
+RESULT = decode_stream
+LIBS = bigarray ffmpeg
+OCAMLFLAGS = -g
+
+INCDIRS = ../../src
+THREADS = yes
+TRASH = *.raw *.flac *.ogg *.mp3 *.mp4 *.mkv
+
+all: nc
+
+test: all
+	./decode_stream ../encode_audio/A4.flac flac A4.mp3 libmp3lame
+	./decode_stream ../encode_audio/A4.mp2 mp2 A4.ogg libvorbis
+
+
+include OCamlMakefile

--- a/examples/decode_stream/Makefile
+++ b/examples/decode_stream/Makefile
@@ -10,8 +10,8 @@ TRASH = *.raw *.flac *.ogg *.mp3 *.mp4 *.mkv
 all: nc
 
 test: all
-	./decode_stream ../encode_audio/A4.flac flac A4.mp3 libmp3lame
-	./decode_stream ../encode_audio/A4.mp2 mp2 A4.ogg libvorbis
+	./decode_stream ../encode_audio/A4.flac A4.mp3 libmp3lame
+	./decode_stream ../encode_audio/A4.mp2 A4.ogg libvorbis
 
 
 include OCamlMakefile

--- a/examples/decode_stream/decode_stream.ml
+++ b/examples/decode_stream/decode_stream.ml
@@ -12,7 +12,6 @@ let () =
   Avutil.Log.set_callback (fun _ -> ());
   
   let in_fd = Unix.openfile Sys.argv.(1) [Unix.O_RDONLY] 0 in
-
   let out_file = Av.open_output Sys.argv.(2) in
   let out_stream = Av.new_audio_stream ~codec_name:Sys.argv.(3) out_file in
 
@@ -21,18 +20,45 @@ let () =
   let container =
     Av.open_input_stream {Av.read;seek}
   in
-  let (_, stream, _) =
+  let (_, stream, codec) =
     Av.find_best_audio_stream container
   in
+  let codec_id = Avcodec.Audio.get_id codec in
+  let sample_format =
+    match Avcodec.Audio.get_sample_format codec with
+      | `Dbl -> "dbl"
+      | `Dblp -> "dblp"
+      | `Flt -> "flt"
+      | `Fltp -> "fltp"
+      | `None -> "none"
+      | `S16 -> "s16"
+      | `S16p -> "s16p"
+      | `S32 -> "s32"
+      | `S32p -> "s32p"
+      | `S64 -> "s64"
+      | `S64p -> "s64p"
+      | `U8 -> "u8"
+      | `U8p -> "u8p"
+  in
+  Printf.printf "Detected codec: %s, %dHz, %d channels, %s\n%!"
+     (Avcodec.Audio.get_name codec_id) (Avcodec.Audio.get_sample_rate codec)
+     (Avcodec.Audio.get_nb_channels codec) sample_format;
   let rec f () =
-    match Av.read_frame stream with
-      | `Frame frame ->
-           Av.write_frame out_stream frame;
-           f ()
-      | `End_of_file -> ()
+    try
+      match Av.read_frame stream with
+        | `Frame frame ->
+             Av.write_frame out_stream frame;
+             f ()
+        | `End_of_file ->
+             Printf.printf "Stream EOF!\n%!";
+             ()
+    with
+      | FFmpeg.Avutil.Error `Invalid_data ->
+          f ()
   in
   f ();
 
+  Printf.printf "Done here!\n%!";
   Unix.close in_fd;
   Av.close out_file;
 

--- a/examples/decode_stream/decode_stream.ml
+++ b/examples/decode_stream/decode_stream.ml
@@ -2,6 +2,9 @@ open FFmpeg
 open Avcodec
 
 let () =
+  Printexc.record_backtrace true
+
+let () =
   if Array.length Sys.argv < 4 then (
     Printf.eprintf "      usage: %s <input file> <output file> <output codec>
       API example program to show how to read audio frames from an input file using the streaming API.
@@ -45,20 +48,15 @@ let () =
      (Avcodec.Audio.get_nb_channels codec) sample_format;
   let rec f () =
     try
-      match Av.read_frame stream with
-        | `Frame frame ->
-             Av.write_frame out_stream frame;
-             f ()
-        | `End_of_file ->
-             Printf.printf "Stream EOF!\n%!";
-             ()
+      Av.write_frame out_stream (Av.read_frame stream);
+      f ()
     with
+      | FFmpeg.Avutil.Error `Eof -> ()
       | FFmpeg.Avutil.Error `Invalid_data ->
           f ()
   in
   f ();
 
-  Printf.printf "Done here!\n%!";
   Unix.close in_fd;
   Av.close out_file;
 

--- a/examples/demuxing_decoding/Makefile
+++ b/examples/demuxing_decoding/Makefile
@@ -6,7 +6,7 @@ INCDIRS = ../../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: dnc
+all: nc
 
 test: all
 	./demuxing_decoding ../encoding/out.mkv vo.raw ao.raw

--- a/examples/demuxing_decoding/demuxing_decoding.ml
+++ b/examples/demuxing_decoding/demuxing_decoding.ml
@@ -49,8 +49,8 @@ let () =
       let _, _, lines = Subtitle.frame_to_lines sf in
       lines |> List.iter print_endline;
       decode()
-    | `End_of_file -> ()
-    | exception Failure msg -> prerr_endline msg
+    | exception Error `Eof -> ()
+    | exception Error err -> prerr_endline (Avutil.string_of_error err)
   in
   decode();
 

--- a/examples/encode_audio/Makefile
+++ b/examples/encode_audio/Makefile
@@ -6,7 +6,7 @@ INCDIRS = ../../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp2 *.mp4 *.mkv
 
-all: dc
+all: nc
 
 test: all
 	./encode_audio A4.flac flac

--- a/examples/encode_audio/encode_audio.ml
+++ b/examples/encode_audio/encode_audio.ml
@@ -5,6 +5,9 @@ module Resampler = Swresample.Make (Swresample.FloatArray) (Swresample.Frame)
 let (%>) f g x = g(f x)
 
 let () =
+  Printexc.record_backtrace true
+
+let () =
   if Array.length Sys.argv < 3 then (
     Printf.eprintf "Usage: %s <output file> <codec name>\n" Sys.argv.(0);
     exit 1);
@@ -15,7 +18,6 @@ let () =
   let pi = 4.0 *. atan 1.0 in let sample_rate = 44100 in let frame_size = 512 in
 
   let codec_id = Audio.find_id Sys.argv.(2) in
-
   let encoder = Audio.create_encoder codec_id in
   let out_sample_format = Audio.find_best_sample_format codec_id `Dbl in
 

--- a/examples/encode_video/Makefile
+++ b/examples/encode_video/Makefile
@@ -8,7 +8,7 @@ CFLAGS = -O3
 OCAMLFLAGS = -unsafe -inline 100 -noassert
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: native-code
+all: nc
 
 test: all
 	./encode_video video.ogg libtheora

--- a/examples/encoding/Makefile
+++ b/examples/encoding/Makefile
@@ -8,7 +8,7 @@ CFLAGS = -O3
 OCAMLFLAGS = -unsafe -inline 10 -noassert
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: native-code
+all: nc
 
 test: all
 	./encoding out.mkv aac mpeg4 ass

--- a/examples/player/Makefile
+++ b/examples/player/Makefile
@@ -5,7 +5,7 @@ LIBS = bigarray ffmpeg
 INCDIRS = ../../src
 THREADS = yes
 
-all: dc
+all: nc
 
 test: all
 	./player ../encoding/out.mkv

--- a/examples/player/player.ml
+++ b/examples/player/player.ml
@@ -18,7 +18,7 @@ let () =
       Av.select input_stream;
 
       ((fun _ frame -> Av.write_audio_frame dst frame), (fun() -> Av.close dst))
-    with Avutil.Failure _ -> ((fun _ _ -> ()), (fun() -> ())) in
+    with Avutil.Error _ -> ((fun _ _ -> ()), (fun() -> ())) in
 
   let video, close_video = try
       let _, input_stream, _ = Av.find_best_video_stream src in
@@ -28,7 +28,7 @@ let () =
       Av.select input_stream;
 
       ((fun _ frame -> Av.write_video_frame dst frame), (fun() -> Av.close dst))
-    with Avutil.Failure _ -> ((fun _ _ -> ()), (fun() -> ())) in
+    with Avutil.Error _ -> ((fun _ _ -> ()), (fun() -> ())) in
 
   Av.iter_input_frame ~audio ~video src;
 

--- a/examples/remuxing/Makefile
+++ b/examples/remuxing/Makefile
@@ -6,7 +6,7 @@ INCDIRS = ../../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: dc
+all: nc
 
 test: all
 	./remuxing ../encoding/out.mkv out.mp4

--- a/examples/transcoding/Makefile
+++ b/examples/transcoding/Makefile
@@ -6,7 +6,7 @@ INCDIRS = ../../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: dnc
+all: nc
 
 test: all
 	./transcoding ../encoding/out.mkv out.mp4

--- a/examples/transcoding/transcoding.ml
+++ b/examples/transcoding/transcoding.ml
@@ -1,6 +1,9 @@
 open FFmpeg
 
 let () =
+  Printexc.record_backtrace true
+
+let () =
   if Array.length Sys.argv < 3 then (
     Printf.printf"usage: %s input_file output_file\n" Sys.argv.(0);
     exit 1);

--- a/ffmpeg.opam
+++ b/ffmpeg.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ffmpeg"
-version: "0.2.1"
+version: "0.3.0"
 maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-ffmpeg"
@@ -13,6 +13,7 @@ depends: [
   "conf-pkg-config" {build}
   "conf-autoconf" {build}
   "base-bigarray"
+  "base-threads"
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/src/av.ml
+++ b/src/av.ml
@@ -214,7 +214,7 @@ let new_audio_stream ?codec_id ?codec_name ?channel_layout ?sample_format ?bit_r
       | Some cn -> Avcodec.Audio.find_id cn
       | None -> match codec with
         | Some cp -> Avcodec.Audio.get_id cp
-        | None -> raise(Failure "Audio codec undefined")
+        | None -> raise (Error (`Failure "Audio codec undefined"))
   in
   let cl = match channel_layout with
     | Some cl -> cl
@@ -265,19 +265,19 @@ let new_video_stream ?codec_id ?codec_name ?width ?height ?pixel_format ?bit_rat
       | Some cn -> Avcodec.Video.find_id cn
       | None -> match codec with
         | Some cp -> Avcodec.Video.get_id cp
-        | None -> raise(Failure "Video codec undefined")
+        | None -> raise (Error (`Failure "Video codec undefined"))
   in
   let w = match width with
     | Some w -> w
     | None -> match codec with
       | Some cp -> Avcodec.Video.get_width cp
-      | None -> raise(Failure "Video width undefined")
+      | None -> raise (Error (`Failure "Video width undefined"))
   in
   let h = match height with
     | Some h -> h
     | None -> match codec with
       | Some cp -> Avcodec.Video.get_height cp
-      | None -> raise(Failure "Video height undefined")
+      | None -> raise (Error (`Failure "Video height undefined"))
   in
   let pf = match pixel_format with
     | Some pf -> pf
@@ -316,7 +316,7 @@ let new_subtitle_stream ?codec_id ?codec_name ?codec ?time_base ?stream o =
       | Some cn -> Avcodec.Subtitle.find_id cn
       | None -> match codec with
         | Some cp -> Avcodec.Subtitle.get_id cp
-        | None -> raise(Failure "Subtitle codec undefined")
+        | None -> raise (Error (`Failure "Subtitle codec undefined"))
   in
   let tb = match time_base with
     | Some tb -> tb

--- a/src/av.mli
+++ b/src/av.mli
@@ -32,10 +32,10 @@ end
 (** {5 Input} *)
 
 val open_input : string -> input container
-(** [Av.open_input url] open the input [url] (a file name or http URL). @raise Failure if the opening failed. *)
+(** [Av.open_input url] open the input [url] (a file name or http URL). @raise Error if the opening failed. *)
 
 val open_input_format : (input, _)format -> input container
-(** [Av.open_input_format format] open the input [format]. @raise Failure if the opening failed. *)
+(** [Av.open_input_format format] open the input [format]. @raise Error if the opening failed. *)
 
 type read_callbacks = {
   read : bytes -> int -> int -> int;
@@ -65,7 +65,7 @@ val get_subtitle_streams : input container -> (int * (input, subtitle)stream * s
 
 
 val find_best_audio_stream : input container -> (int * (input, audio)stream * audio Avcodec.t)
-(** Return the best audio stream of the input. The result is a tuple containing the index of the stream in the container, the stream and the codec of the stream. @raise Failure if no stream could be found. *)
+(** Return the best audio stream of the input. The result is a tuple containing the index of the stream in the container, the stream and the codec of the stream. @raise Error if no stream could be found. *)
 
 val find_best_video_stream : input container -> (int * (input, video)stream * video Avcodec.t)
 (** Same as {!Av.find_best_audio_stream} for the video streams. *)
@@ -80,7 +80,7 @@ val get_index : (_, _)stream -> int
 (** Return the index of the stream. *)
 
 val get_codec : (_, 'media)stream -> 'media Avcodec.t
-(** [Av.get_codec stream] return the codec of the [stream]. @raise Failure if the codec allocation failed. *)
+(** [Av.get_codec stream] return the codec of the [stream]. @raise Error if the codec allocation failed. *)
 
 val get_time_base : (_, _)stream -> Avutil.rational
 (** [Av.get_time_base stream] return the time base of the [stream]. *)
@@ -95,25 +95,25 @@ val get_metadata : (input, _)stream -> (string * string) list
 (** Same as {!Av.get_input_metadata} for the input streams. *)
 
 val select : (input, _)stream -> unit
-(** [Av.select stream] select the input [stream] for reading. @raise Failure if the selection failed. *)
+(** [Av.select stream] select the input [stream] for reading. @raise Error if the selection failed. *)
 
 (** Stream packet reading result. *)
 type 'media stream_packet_result = [ `Packet of 'media Avcodec.Packet.t | `End_of_file ]
 
 val read_packet : (input, 'media)stream -> 'media stream_packet_result
-(** [Av.read_packet stream] read the input [stream]. Return the next packet of the [stream] or [End_of_file] if the end of the stream is reached. @raise Failure if the reading failed. *)
+(** [Av.read_packet stream] read the input [stream]. Return the next packet of the [stream] or [End_of_file] if the end of the stream is reached. @raise Error if the reading failed. *)
 
 val iter_packet : ('media Avcodec.Packet.t -> unit) -> (input, 'media)stream -> unit
-(** [Av.iter_packet f is] applies function [f] in turn to all the packets of the input stream [is]. @raise Failure if the reading failed. *)
+(** [Av.iter_packet f is] applies function [f] in turn to all the packets of the input stream [is]. @raise Error if the reading failed. *)
 
 (** Stream frame reading result. *)
 type 'media stream_frame_result = [ `Frame of 'media frame | `End_of_file ]
 
 val read_frame : (input, 'media)stream -> 'media stream_frame_result
-(** [Av.read_frame stream] read the input [stream]. Return the next frame of the [stream] or [End_of_file] if the end of the stream is reached. @raise Failure if the reading failed. *)
+(** [Av.read_frame stream] read the input [stream]. Return the next frame of the [stream] or [End_of_file] if the end of the stream is reached. @raise Error if the reading failed. *)
 
 val iter_frame : ('media frame -> unit) -> (input, 'media)stream -> unit
-(** [Av.iter_frame f is] applies function [f] in turn to all the frames of the input stream [is]. @raise Failure if the reading failed. *)
+(** [Av.iter_frame f is] applies function [f] in turn to all the frames of the input stream [is]. @raise Error if the reading failed. *)
 
 
 type input_packet_result = [
@@ -124,13 +124,13 @@ type input_packet_result = [
 ]
 
 val read_input_packet : input container -> input_packet_result
-(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and packet of the input or [End_of_file] if the end of the input is reached. @raise Failure if the reading failed. *)
+(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and packet of the input or [End_of_file] if the end of the input is reached. @raise Error if the reading failed. *)
 
 val iter_input_packet : ?audio:(int -> audio Avcodec.Packet.t -> unit) ->
   ?video:(int -> video Avcodec.Packet.t -> unit) ->
   ?subtitle:(int -> subtitle Avcodec.Packet.t -> unit) ->
   input container -> unit
-(** [Av.iter_input_packet ~audio:af ~video:vf ~subtitle:sf src] reads iteratively the selected streams if any or all streams of the [src] input otherwise. It applies function [af] to the audio packets, [vf] to the video packets and [sf] to the subtitle packets with the index of the related stream as first parameter. @raise Failure if the reading failed. *)
+(** [Av.iter_input_packet ~audio:af ~video:vf ~subtitle:sf src] reads iteratively the selected streams if any or all streams of the [src] input otherwise. It applies function [af] to the audio packets, [vf] to the video packets and [sf] to the subtitle packets with the index of the related stream as first parameter. @raise Error if the reading failed. *)
 
 
 type input_frame_result = [
@@ -141,20 +141,20 @@ type input_frame_result = [
 ]
 
 val read_input_frame : input container -> input_frame_result
-(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and frame of the input or [End_of_file] if the end of the input is reached. @raise Failure if the reading failed. *)
+(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and frame of the input or [End_of_file] if the end of the input is reached. @raise Error if the reading failed. *)
 
 val iter_input_frame : ?audio:(int -> audio frame -> unit) ->
   ?video:(int -> video frame -> unit) ->
   ?subtitle:(int -> subtitle frame -> unit) ->
   input container -> unit
-(** [Av.iter_input_frame ~audio:af ~video:vf ~subtitle:sf src] reads iteratively the selected streams if any or all streams of the [src] input otherwise. It applies function [af] to the audio frames, [vf] to the video frames and [sf] to the subtitle frames with the index of the related stream as first parameter. @raise Failure if the reading failed. *)
+(** [Av.iter_input_frame ~audio:af ~video:vf ~subtitle:sf src] reads iteratively the selected streams if any or all streams of the [src] input otherwise. It applies function [af] to the audio frames, [vf] to the video frames and [sf] to the subtitle frames with the index of the related stream as first parameter. @raise Error if the reading failed. *)
 
 
 (** Seek mode. *)
 type seek_flag = Seek_flag_backward | Seek_flag_byte | Seek_flag_any | Seek_flag_frame
 
 val seek : (input, _)stream -> Time_format.t -> Int64.t -> seek_flag array -> unit
-(** [Av.seek is fmt t flags] seek in the input stream [is] at the position [t] in the [fmt] time format according to the method indicated by the [flags]. @raise Failure if the seeking failed. *)
+(** [Av.seek is fmt t flags] seek in the input stream [is] at the position [t] in the [fmt] time format according to the method indicated by the [flags]. @raise Error if the seeking failed. *)
 
 val reuse_output : input container -> bool -> unit
 (** [Av.reuse_output ro] enables or disables the reuse of {!Av.read_packet}, {!Av.iter_packet}, {!Av.read_frame}, {!Av.iter_frame}, {!Av.read_input_packet}, {!Av.iter_input_packet}, {!Av.read_input_frame} and {!Av.iter_input_frame} output according to the value of [ro]. Reusing the output reduces the number of memory allocations. In this cas, the data returned by a reading function is invalidated by a new call to this function. *)
@@ -163,17 +163,17 @@ val reuse_output : input container -> bool -> unit
 (** {5 Output} *)
 
 val open_output : string -> output container
-(** [Av.open_output filename] open the output file named [filename]. @raise Failure if the opening failed. *)
+(** [Av.open_output filename] open the output file named [filename]. @raise Error if the opening failed. *)
 
 val open_output_format : (output, _) format -> output container
-(** [Av.open_output_format format] open the output [format]. @raise Failure if the opening failed. *)
+(** [Av.open_output_format format] open the output [format]. @raise Error if the opening failed. *)
 
 val open_output_format_name : string -> output container
-(** [Av.open_output_format_name name] open the output format of name [name]. @raise Failure if the opening failed. *)
+(** [Av.open_output_format_name name] open the output format of name [name]. @raise Error if the opening failed. *)
 
 
 val set_output_metadata : output container -> (string * string) list -> unit
-(** [Av.set_output_metadata dst tags] set the metadata of the [dst] output with the [tags] tag list. This must be set before starting writing streams. @raise Failure if a writing already taken place or if the setting failed. *)
+(** [Av.set_output_metadata dst tags] set the metadata of the [dst] output with the [tags] tag list. This must be set before starting writing streams. @raise Error if a writing already taken place or if the setting failed. *)
 
 
 val set_metadata : (output, _)stream -> (string * string) list -> unit
@@ -185,7 +185,7 @@ val get_output : (output, _)stream -> output container
 
 
 val new_audio_stream : ?codec_id:Avcodec.Audio.id -> ?codec_name:string -> ?channel_layout:Channel_layout.t -> ?sample_format:Sample_format.t -> ?bit_rate:int -> ?sample_rate:int -> ?codec:audio Avcodec.t -> ?time_base:Avutil.rational -> ?stream:(_, audio)stream -> output container -> (output, audio)stream
-(** [Av.new_audio_stream ~codec_id:ci ~codec_name:cn ~channel_layout:cl ~sample_format:sf ~bit_rate:br ~sample_rate:sr ~codec:c ~time_base:tb ~stream:s dst] add a new audio stream to the [dst] media file. Parameters [ci], [cn], [cl], [sf], [br], [sr] passed unitarily take precedence over those of the [c] codec. The [c] codec and [tb] time base parameters take precedence over those of the [s] stream. This must be set before starting writing streams. @raise Failure if a writing already taken place or if the stream allocation failed. *)
+(** [Av.new_audio_stream ~codec_id:ci ~codec_name:cn ~channel_layout:cl ~sample_format:sf ~bit_rate:br ~sample_rate:sr ~codec:c ~time_base:tb ~stream:s dst] add a new audio stream to the [dst] media file. Parameters [ci], [cn], [cl], [sf], [br], [sr] passed unitarily take precedence over those of the [c] codec. The [c] codec and [tb] time base parameters take precedence over those of the [s] stream. This must be set before starting writing streams. @raise Error if a writing already taken place or if the stream allocation failed. *)
 
 
 val new_video_stream : ?codec_id:Avcodec.Video.id -> ?codec_name:string -> ?width:int -> ?height:int -> ?pixel_format:Pixel_format.t -> ?bit_rate:int -> ?frame_rate:int -> ?codec:video Avcodec.t -> ?time_base:Avutil.rational -> ?stream:(_, video)stream -> output container -> (output, video)stream
@@ -197,14 +197,14 @@ val new_subtitle_stream : ?codec_id:Avcodec.Subtitle.id -> ?codec_name:string ->
 
 
 val write_packet : (output, 'media)stream -> 'media Avcodec.Packet.t -> unit
-(** [Av.write_packet os pkt] write the [pkt] packet to the [os] output stream. @raise Failure if the writing failed. *)
+(** [Av.write_packet os pkt] write the [pkt] packet to the [os] output stream. @raise Error if the writing failed. *)
 
 
 val write_frame : (output, 'media)stream -> 'media frame -> unit
-(** [Av.write_frame os frm] write the [frm] frame to the [os] output stream. @raise Failure if the writing failed. *)
+(** [Av.write_frame os frm] write the [frm] frame to the [os] output stream. @raise Error if the writing failed. *)
 
 val write_audio_frame : output container -> audio frame -> unit
-(** [Av.write_audio_frame dst frm] write the [frm] audio frame to the [dst] output audio container. @raise Failure if the output format is not defined or if the output media type is not compatible with the frame or if the writing failed. *)
+(** [Av.write_audio_frame dst frm] write the [frm] audio frame to the [dst] output audio container. @raise Error if the output format is not defined or if the output media type is not compatible with the frame or if the writing failed. *)
 
 val write_video_frame : output container -> video frame -> unit
 (** Same as {!Av.write_audio_frame} for output video container. *)

--- a/src/av.mli
+++ b/src/av.mli
@@ -97,20 +97,14 @@ val get_metadata : (input, _)stream -> (string * string) list
 val select : (input, _)stream -> unit
 (** [Av.select stream] select the input [stream] for reading. @raise Error if the selection failed. *)
 
-(** Stream packet reading result. *)
-type 'media stream_packet_result = [ `Packet of 'media Avcodec.Packet.t | `End_of_file ]
-
-val read_packet : (input, 'media)stream -> 'media stream_packet_result
-(** [Av.read_packet stream] read the input [stream]. Return the next packet of the [stream] or [End_of_file] if the end of the stream is reached. @raise Error if the reading failed. *)
+val read_packet : (input, 'media)stream -> 'media Avcodec.Packet.t
+(** [Av.read_packet stream] read the input [stream]. Return the next packet of the [stream] or raises [Error `Eof] if the end of the stream is reached. @raise Error if the reading failed. *)
 
 val iter_packet : ('media Avcodec.Packet.t -> unit) -> (input, 'media)stream -> unit
 (** [Av.iter_packet f is] applies function [f] in turn to all the packets of the input stream [is]. @raise Error if the reading failed. *)
 
-(** Stream frame reading result. *)
-type 'media stream_frame_result = [ `Frame of 'media frame | `End_of_file ]
-
-val read_frame : (input, 'media)stream -> 'media stream_frame_result
-(** [Av.read_frame stream] read the input [stream]. Return the next frame of the [stream] or [End_of_file] if the end of the stream is reached. @raise Error if the reading failed. *)
+val read_frame : (input, 'media)stream -> 'media frame
+(** [Av.read_frame stream] read the input [stream]. Return the next frame of the [stream] or raises [Error `Eof] if the end of the stream is reached. @raise Error if the reading failed. *)
 
 val iter_frame : ('media frame -> unit) -> (input, 'media)stream -> unit
 (** [Av.iter_frame f is] applies function [f] in turn to all the frames of the input stream [is]. @raise Error if the reading failed. *)
@@ -120,7 +114,6 @@ type input_packet_result = [
   | `Audio of int * audio Avcodec.Packet.t
   | `Video of int * video Avcodec.Packet.t
   | `Subtitle of int * subtitle Avcodec.Packet.t
-  | `End_of_file
 ]
 
 val read_input_packet : input container -> input_packet_result
@@ -137,11 +130,10 @@ type input_frame_result = [
   | `Audio of int * audio frame
   | `Video of int * video frame
   | `Subtitle of int * subtitle frame
-  | `End_of_file
 ]
 
 val read_input_frame : input container -> input_frame_result
-(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and frame of the input or [End_of_file] if the end of the input is reached. @raise Error if the reading failed. *)
+(** Reads the selected streams if any or all streams otherwise. Return the next [Audio] [Video] or [Subtitle] index and frame of the input or raises [Error `Eof] if the end of the input is reached. @raise Error if the reading failed. *)
 
 val iter_input_frame : ?audio:(int -> audio frame -> unit) ->
   ?video:(int -> video frame -> unit) ->

--- a/src/av_stubs.c
+++ b/src/av_stubs.c
@@ -101,9 +101,7 @@ static void free_stream(stream_t * stream)
 {
   if( ! stream) return;
   
-  if(stream->codec_context) {
-    avcodec_free_context(&stream->codec_context);
-  }
+  if(stream->codec_context) avcodec_free_context(&stream->codec_context);
 
   if(stream->swr_ctx) {
     swr_free(&stream->swr_ctx);
@@ -1911,7 +1909,11 @@ CAMLprim value ocaml_av_close(value _av)
     av_write_trailer(av->format_context);
     caml_acquire_runtime_system();
   }
+  // Close is called both from the Gc context and here so 
+  // we have to release runtime only here (yes, it does log!)
+  caml_release_runtime_system();
   close_av(av);
+  caml_acquire_runtime_system();
 
   CAMLreturn(Val_unit);
 }

--- a/src/av_stubs.c
+++ b/src/av_stubs.c
@@ -143,8 +143,6 @@ static void close_av(av_t * av)
       av->streams = NULL;
     }
 
-    caml_release_runtime_system();
-
     if(av->format_context->iformat) {
       avformat_close_input(&av->format_context);
     }
@@ -158,8 +156,6 @@ static void close_av(av_t * av)
 
       av->format_context = NULL;
     }
-
-    caml_acquire_runtime_system();
 
     av->best_audio_stream = NULL;
     av->best_video_stream = NULL;

--- a/src/av_stubs.c
+++ b/src/av_stubs.c
@@ -1690,7 +1690,7 @@ static inline void write_audio_frame(av_t * av, int stream_index, AVFrame * fram
 
         int read_size = av_audio_fifo_read(fifo, (void **)output_frame->data, frame_size);
 
-        if (read_size < frame_size) {
+        if (frame && read_size < frame_size) {
           caml_acquire_runtime_system();
           Fail("Invalid input: read_size < frame_size");
         }

--- a/src/av_stubs.c
+++ b/src/av_stubs.c
@@ -101,8 +101,6 @@ static void free_stream(stream_t * stream)
 {
   if( ! stream) return;
   
-  caml_release_runtime_system();
-
   if(stream->codec_context) {
     avcodec_free_context(&stream->codec_context);
   }
@@ -126,8 +124,6 @@ static void free_stream(stream_t * stream)
   if(stream->enc_frame) {
     av_frame_free(&stream->enc_frame);
   }
-
-  caml_acquire_runtime_system();
 
   free(stream);
 }

--- a/src/avcodec.mli
+++ b/src/avcodec.mli
@@ -29,7 +29,7 @@ module Packet : sig
 
   val parse_data : 'a parser -> ('a t -> unit) -> data -> unit
   (** [Avcodec.Packet.parse_data parser f data] applies function [f] to the parsed packets frome the [data] array according to the [parser] configuration.
-    @raise Failure if the parsing failed. *)
+    @raise Error if the parsing failed. *)
 
   val parse_bytes : 'a parser -> ('a t -> unit) -> bytes -> int -> unit
   (** Same as {!Avcodec.Packet.parse_data} with bytes array. *)
@@ -47,7 +47,7 @@ module Audio : sig
 
   val find_id : string -> id
   (** Return the id of a codec from his name.
-      @raise Failure if the codec is not found or is not an audio codec. *)
+      @raise Error if the codec is not found or is not an audio codec. *)
 
   (** Return the list of supported channel layouts of the codec. *)
   val get_supported_channel_layouts : id -> Avutil.Channel_layout.t list
@@ -87,15 +87,15 @@ module Audio : sig
 
   val create_parser : id -> audio Packet.parser
   (** [Avcodec.Audio.create_parser id] create an audio packet parser.
-      @raise Failure if the parser creation failed. *)
+      @raise Error if the parser creation failed. *)
 
   val create_decoder : id -> audio decoder
   (** [Avcodec.Audio.create_decoder id] create an audio decoder.
-      @raise Failure if the decoder creation failed. *)
+      @raise Error if the decoder creation failed. *)
 
   val create_encoder : ?bit_rate:int -> id -> audio encoder
   (** [Avcodec.Audio.create_encoder ~bit_rate:bit_rate id] create an audio encoder.
-      @raise Failure if the encoder creation failed. *)
+      @raise Error if the encoder creation failed. *)
 end
 
 (** Video codecs. *)
@@ -108,7 +108,7 @@ module Video : sig
 
   val find_id : string -> id
   (** Return the id of a codec from his name.
-      @raise Failure if the codec is not found or is not a video codec. *)
+      @raise Error if the codec is not found or is not a video codec. *)
 
   (** Return the list of supported frame rates of the codec. *)
   val get_supported_frame_rates : id -> Avutil.rational list
@@ -144,15 +144,15 @@ module Video : sig
 
   val create_parser : id -> video Packet.parser
   (** [Avcodec.Video.create_parser id] create an video packet parser.
-      @raise Failure if the parser creation failed. *)
+      @raise Error if the parser creation failed. *)
 
   val create_decoder : id -> video decoder
   (** [Avcodec.Video.create_decoder id] create a video decoder.
-      @raise Failure if the decoder creation failed. *)
+      @raise Error if the decoder creation failed. *)
 
   val create_encoder : ?bit_rate:int -> ?frame_rate:int -> id -> video encoder
   (** [Avcodec.Video.create_encoder ~bit_rate:bit_rate id] create a video encoder.
-      @raise Failure if the encoder creation failed. *)
+      @raise Error if the encoder creation failed. *)
 end
 
 (** Subtitle codecs. *)
@@ -165,7 +165,7 @@ module Subtitle : sig
 
   val find_id : string -> id
   (** Return the id of a codec from his name.
-      @raise Failure if the codec is not found or is not a subtitle codec. *)
+      @raise Error if the codec is not found or is not a subtitle codec. *)
 
   (** Return the id of the codec. *)
   val get_id : subtitle t -> id
@@ -174,16 +174,16 @@ end
 
 val decode : 'media decoder -> ('media frame -> unit) -> 'media Packet.t -> unit
 (** [Avcodec.decode decoder f packet] applies function [f] to the decoded frames frome the [packet] according to the [decoder] configuration.
-    @raise Failure if the decoding failed. *)
+    @raise Error if the decoding failed. *)
 
 val flush_decoder : 'media decoder -> ('media frame -> unit) -> unit
 (** [Avcodec.flush_decoder decoder f] applies function [f] to the decoded frames frome the buffered packets in the [decoder].
-    @raise Failure if the decoding failed. *)
+    @raise Error if the decoding failed. *)
 
 val encode : 'media encoder -> ('media Packet.t -> unit) -> 'media frame -> unit
 (** [Avcodec.encode encoder f frame] applies function [f] to the encoded packets from the [frame] according to the [encoder] configuration.
-    @raise Failure if the encoding failed. *)
+    @raise Error if the encoding failed. *)
 
 val flush_encoder : 'media encoder -> ('media Packet.t -> unit) -> unit
 (** [Avcodec.flush_encoder encoder] applies function [f] to the encoded packets from the buffered frames in the [encoder].
-    @raise Failure if the encoding failed. *)
+    @raise Error if the encoding failed. *)

--- a/src/avcodec_stubs.c
+++ b/src/avcodec_stubs.c
@@ -45,21 +45,29 @@ CAMLprim value ocaml_avcodec_subtitle_codec_id_to_AVCodecID(value _codec_id) {
 
 /***** AVCodecContext *****/
 
-static AVCodecContext * avcodec_create_AVCodecContext(AVCodec *codec)
+static inline AVCodecContext * avcodec_create_AVCodecContext(AVCodec *codec)
 {
   AVCodecContext *codec_context = NULL;
 
-  if(codec) codec_context = avcodec_alloc_context3(codec);
-
-  if( ! codec_context) {
-    Fail("Failed to allocate codec context");
+  if(codec) {
+    caml_release_runtime_system();
+    codec_context = avcodec_alloc_context3(codec);
+    caml_acquire_runtime_system();
   }
 
+  if( ! codec_context) caml_raise_out_of_memory();
+
   // Open the codec
+  caml_release_runtime_system();
   int ret = avcodec_open2(codec_context, codec, NULL);
+  caml_acquire_runtime_system();
+
   if(ret < 0) {
+    caml_release_runtime_system();
     avcodec_free_context(&codec_context);
-    Fail("Failed to open codec : %s", av_err2str(ret));
+    caml_acquire_runtime_system();
+
+    ocaml_avutil_raise_error(ret);
   }
 
   return codec_context;
@@ -86,13 +94,19 @@ static struct custom_operations codec_parameters_ops =
 
 void value_of_codec_parameters_copy(AVCodecParameters *src, value * pvalue)
 {
-  if( ! src) Raise(EXN_FAILURE, "Failed to get codec parameters");
+  if( ! src) Fail( "Failed to get codec parameters");
 
+  caml_release_runtime_system();
   AVCodecParameters * dst = avcodec_parameters_alloc();
-  if( ! dst) Raise(EXN_FAILURE, "Failed to alloc codec parameters");
+  caml_acquire_runtime_system();
 
+  if( ! dst) caml_raise_out_of_memory();
+
+  caml_release_runtime_system();
   int ret = avcodec_parameters_copy(dst, src);
-  if(ret < 0) Raise(EXN_FAILURE, "Failed to copy codec parameters : %s", av_err2str(ret));
+  caml_acquire_runtime_system();
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   *pvalue = caml_alloc_custom(&codec_parameters_ops, sizeof(AVCodecParameters*), 0, 1);
   CodecParameters_val(*pvalue) = dst;
@@ -104,7 +118,9 @@ void value_of_codec_parameters_copy(AVCodecParameters *src, value * pvalue)
 static void finalize_packet(value v)
 {
   struct AVPacket *packet = Packet_val(v);
+  caml_release_runtime_system();
   av_packet_free(&packet);
+  caml_acquire_runtime_system();
 }
 
 static struct custom_operations packet_ops =
@@ -119,7 +135,7 @@ static struct custom_operations packet_ops =
 
 void value_of_ffmpeg_packet(AVPacket *packet, value * pvalue)
 {
-  if( ! packet) Raise(EXN_FAILURE, "Empty packet");
+  if( ! packet) Fail( "Empty packet");
 
   *pvalue = caml_alloc_custom(&packet_ops, sizeof(AVPacket*), 0, 1);
   Packet_val((*pvalue)) = packet;
@@ -127,8 +143,11 @@ void value_of_ffmpeg_packet(AVPacket *packet, value * pvalue)
 
 AVPacket * alloc_packet_value(value * pvalue)
 {
+  caml_release_runtime_system();
   AVPacket *packet = av_packet_alloc();
-  if( ! packet) Fail("Failed to allocate packet");
+  caml_acquire_runtime_system();
+
+  if( ! packet) caml_raise_out_of_memory();
 
   value_of_ffmpeg_packet(packet, pvalue);
 
@@ -182,9 +201,11 @@ static void free_parser(parser_t *parser)
 {
   if( ! parser) return;
 
+  caml_release_runtime_system();
   if(parser->context) av_parser_close(parser->context);
 
   if(parser->codec_context) avcodec_free_context(&parser->codec_context);
+  caml_acquire_runtime_system();
 
   free(parser);
 }
@@ -204,25 +225,33 @@ static struct custom_operations parser_ops =
     custom_deserialize_default
   };
 
-static parser_t * avcodec_create_parser(enum AVCodecID codec_id)
+static inline parser_t * avcodec_create_parser(enum AVCodecID codec_id)
 {
+  caml_release_runtime_system();
   AVCodec * codec = avcodec_find_decoder(codec_id);
-  if ( ! codec) Fail("Failed to find parser's decoder");
+  caml_acquire_runtime_system();
+
+  if ( ! codec) ocaml_avutil_raise_error(AVERROR_STREAM_NOT_FOUND);
 
   parser_t * parser = (parser_t*)calloc(1, sizeof(parser_t));
-  if ( ! parser) Fail("Failed to allocate parser");
+  if ( ! parser) caml_raise_out_of_memory();
 
+  caml_release_runtime_system();
   parser->context = av_parser_init(codec->id);
+  caml_acquire_runtime_system();
+
   if ( ! parser->context) {
     free_parser(parser);
-    Fail("Failed to init parser context");
+    caml_raise_out_of_memory();
   }
   
+  caml_release_runtime_system();
   parser->codec_context = avcodec_create_AVCodecContext(codec);
+  caml_acquire_runtime_system();
 
   if( ! parser->codec_context) {
     free_parser(parser);
-    return NULL;
+    caml_raise_out_of_memory();
   }
 
   return parser;
@@ -235,8 +264,6 @@ CAMLprim value ocaml_avcodec_create_parser(value _codec_id) {
   caml_release_runtime_system();
   parser_t * parser = avcodec_create_parser((enum AVCodecID)Int_val(_codec_id));
   caml_acquire_runtime_system();
-
-  if( ! parser) Raise(EXN_FAILURE, "%s", ocaml_av_error_msg);
 
   ans = caml_alloc_custom(&parser_ops, sizeof(parser_t*), 0, 1);
   Parser_val(ans) = parser;
@@ -254,10 +281,14 @@ CAMLprim value ocaml_avcodec_parse_packet(value _parser, value _data, value _ofs
   size_t len = init_len;
   int ret = 0;
   
+  caml_release_runtime_system();
   AVPacket *packet = av_packet_alloc();
-  if( ! packet) Raise(EXN_FAILURE, "Failed to allocate packet");
+  caml_acquire_runtime_system();
+
+  if( ! packet) caml_raise_out_of_memory();
 
   caml_release_runtime_system();
+
   do {
     ret = av_parser_parse2(parser->context, parser->codec_context,
                            &packet->data, &packet->size,
@@ -266,12 +297,13 @@ CAMLprim value ocaml_avcodec_parse_packet(value _parser, value _data, value _ofs
     len -= ret;
   } while(packet->size == 0 && ret > 0);
 
-  caml_acquire_runtime_system();
-
   if (ret < 0) {
     av_packet_free(&packet);
-    Raise(EXN_FAILURE, "Failed to parse data : %s", av_err2str(ret));
+    caml_acquire_runtime_system();
+    ocaml_avutil_raise_error(ret);
   }
+
+  caml_acquire_runtime_system();
 
   if(packet->size) {
     value_of_ffmpeg_packet(packet, &val_packet);
@@ -285,7 +317,10 @@ CAMLprim value ocaml_avcodec_parse_packet(value _parser, value _data, value _ofs
     Store_field(ans, 0, tuple);
   }
   else {
+    caml_release_runtime_system();
     av_packet_free(&packet);
+    caml_acquire_runtime_system();
+
     ans = Val_int(0);
   }
   
@@ -313,6 +348,7 @@ static void free_codec_context(codec_context_t *ctx)
 {
   if( ! ctx) return;
 
+  caml_release_runtime_system();
   if(ctx->codec_context) avcodec_free_context(&ctx->codec_context);
 
   if(ctx->audio_fifo) {
@@ -322,6 +358,7 @@ static void free_codec_context(codec_context_t *ctx)
   if(ctx->enc_frame) {
     av_frame_free(&ctx->enc_frame);
   }
+  caml_acquire_runtime_system();
 
   free(ctx);
 }
@@ -341,10 +378,12 @@ static struct custom_operations codec_context_ops =
     custom_deserialize_default
   };
 
-static codec_context_t * avcodec_create_codec_context(enum AVCodecID codec_id, int decoder)
+static inline codec_context_t * avcodec_create_codec_context(enum AVCodecID codec_id, int decoder)
 {
   codec_context_t * ctx = (codec_context_t*)calloc(1, sizeof(codec_context_t));
-  if ( ! ctx) Fail("Failed to allocate codec context");
+  if ( ! ctx) caml_raise_out_of_memory();
+
+  caml_release_runtime_system();
 
   if(decoder) {
     ctx->codec = avcodec_find_decoder(codec_id);
@@ -353,7 +392,9 @@ static codec_context_t * avcodec_create_codec_context(enum AVCodecID codec_id, i
 
     if( ! ctx->codec_context) {
       free_codec_context(ctx);
-      return NULL;
+
+      caml_acquire_runtime_system();
+      caml_raise_out_of_memory();
     }
   }
   else {
@@ -361,10 +402,14 @@ static codec_context_t * avcodec_create_codec_context(enum AVCodecID codec_id, i
 
     if( ! ctx->codec) {
       free_codec_context(ctx);
-      Fail("Failed to find codec");
+
+      caml_acquire_runtime_system();
+      ocaml_avutil_raise_error(AVERROR_ENCODER_NOT_FOUND);
     }
     // in case of encoding, the AVCodecContext will be created with the properties of the first sended frame
   }
+
+  caml_acquire_runtime_system();
 
   return ctx;
 }
@@ -377,8 +422,6 @@ CAMLprim value ocaml_avcodec_create_context(value _codec_id, value _decoder, val
   codec_context_t * ctx = avcodec_create_codec_context((enum AVCodecID)Int_val(_codec_id), Int_val(_decoder));
   caml_acquire_runtime_system();
 
-  if( ! ctx) Raise(EXN_FAILURE, "%s", ocaml_av_error_msg);
-
   ans = caml_alloc_custom(&codec_context_ops, sizeof(codec_context_t*), 0, 1);
   CodecContext_val(ans) = ctx;
 
@@ -389,16 +432,19 @@ CAMLprim value ocaml_avcodec_create_context(value _codec_id, value _decoder, val
 }
 
 
-static AVCodecContext * avcodec_open_codec(codec_context_t *ctx, AVFrame *frame)
+static inline AVCodecContext * avcodec_open_codec(codec_context_t *ctx, AVFrame *frame)
 {
-  if( ! frame) Fail("Failed to open encoder without frame");
+  if( ! frame) Fail( "Failed to open encoder without frame");
   
   AVCodec *codec = ctx->codec;
   
-  if(codec->type != AVMEDIA_TYPE_AUDIO && codec->type != AVMEDIA_TYPE_VIDEO) Fail("Failed to open unsupported encoder type");
+  if(codec->type != AVMEDIA_TYPE_AUDIO && codec->type != AVMEDIA_TYPE_VIDEO) Fail( "Failed to open unsupported encoder type");
 
+  caml_release_runtime_system();
   ctx->codec_context = avcodec_alloc_context3(codec);
-  if( ! ctx->codec_context) Fail("Failed to allocate encoder context");
+  caml_acquire_runtime_system();
+
+  if( ! ctx->codec_context) caml_raise_out_of_memory();
 
   if(codec->type == AVMEDIA_TYPE_AUDIO) {
     ctx->codec_context->channel_layout = frame->channel_layout;
@@ -418,27 +464,39 @@ static AVCodecContext * avcodec_open_codec(codec_context_t *ctx, AVFrame *frame)
   ctx->codec_context->bit_rate = ctx->bit_rate;
 
   // Open the codec
+  caml_release_runtime_system();
   int ret = avcodec_open2(ctx->codec_context, NULL, NULL);
-  if(ret < 0) Fail("Failed to open encoder : %s", av_err2str(ret));
+  caml_acquire_runtime_system();
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   if (ctx->codec_context->frame_size > 0
       || ! (ctx->codec_context->codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE)) {
 
     // Allocate the buffer frame and audio fifo if the codec doesn't support variable frame size
+    caml_release_runtime_system();
     ctx->enc_frame = av_frame_alloc();
-    if( ! ctx->enc_frame) Fail("Failed to allocate encoder frame");
+    caml_acquire_runtime_system();
+
+    if( ! ctx->enc_frame) caml_raise_out_of_memory();
 
     ctx->enc_frame->nb_samples     = ctx->codec_context->frame_size;
     ctx->enc_frame->channel_layout = ctx->codec_context->channel_layout;
     ctx->enc_frame->format         = ctx->codec_context->sample_fmt;
     ctx->enc_frame->sample_rate    = ctx->codec_context->sample_rate;
 
+    caml_release_runtime_system();
     int ret = av_frame_get_buffer(ctx->enc_frame, 0);
-    if (ret < 0) Fail("Failed to allocate encoder frame samples : %s)", av_err2str(ret));
+    caml_acquire_runtime_system();
+
+    if (ret < 0) ocaml_avutil_raise_error(ret);
 
     // Create the FIFO buffer based on the specified output sample format.
+    caml_release_runtime_system();
     ctx->audio_fifo = av_audio_fifo_alloc(ctx->codec_context->sample_fmt, ctx->codec_context->channels, 1);
-    if( ! ctx->audio_fifo) Fail("Failed to allocate audio FIFO");
+    caml_acquire_runtime_system();
+
+    if( ! ctx->audio_fifo) caml_raise_out_of_memory();
   }
 
   return ctx->codec_context;
@@ -451,12 +509,12 @@ CAMLprim value ocaml_avcodec_send_packet(value _ctx, value _packet)
   codec_context_t *ctx = CodecContext_val(_ctx);
   AVPacket *packet = _packet ? Packet_val(_packet) : NULL;
 
-  caml_release_runtime_system();
   // send the packet with the compressed data to the decoder
+  caml_release_runtime_system();
   int ret = avcodec_send_packet(ctx->codec_context, packet);
   caml_acquire_runtime_system();
 
-  if(ret < 0 && ret != AVERROR_EOF && ret != AVERROR(EAGAIN)) Raise(EXN_FAILURE, "Failed to decode data : %s", av_err2str(ret));
+  if(ret < 0 && ret != AVERROR_EOF && ret != AVERROR(EAGAIN)) ocaml_avutil_raise_error(ret);
 
   if (ret == AVERROR(EAGAIN)) ans = PVV_Again;
   else ans = PVV_Ok;
@@ -478,12 +536,12 @@ CAMLprim value ocaml_avcodec_receive_frame(value _ctx)
   }
   caml_acquire_runtime_system();
   
-  if (!frame) Raise(EXN_FAILURE, "Failed to allocate frame");
+  if (!frame) caml_raise_out_of_memory();
 
   if (ret < 0) {
     av_frame_free(&frame);
     if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) ans = Val_int(0);
-    else Raise(EXN_FAILURE, "Failed to receive frame : %s", av_err2str(ret));
+    else ocaml_avutil_raise_error(ret);
   }
   else {
     ans = caml_alloc(1, 0);
@@ -499,26 +557,35 @@ CAMLprim value ocaml_avcodec_flush_decoder(value _ctx) {
   return Val_unit;
 }
 
-static int send_audio_fifo_frame(codec_context_t *ctx)
+static inline void send_audio_fifo_frame(codec_context_t *ctx)
 {
   AVFrame * frame = ctx->enc_frame;
   int frame_size = ctx->codec_context->frame_size;
   AVAudioFifo *fifo = ctx->audio_fifo;
-  int ret, fifo_size = av_audio_fifo_size(fifo);
+  int ret;
+
+  caml_release_runtime_system();
+  int fifo_size = av_audio_fifo_size(fifo);
+  caml_acquire_runtime_system();
 
   if(fifo_size < frame_size) {
     if(ctx->flushed) frame_size = fifo_size;
-    else return AVERROR_EOF;
+    else ocaml_avutil_raise_error(AVERROR_EOF);
   }
     
   if(fifo_size > 0) {
+    caml_release_runtime_system();
     ret = av_frame_make_writable(frame);
-    if (ret < 0) return ret;
+    caml_acquire_runtime_system();
 
+    if (ret < 0) ocaml_avutil_raise_error(ret);
+
+    caml_release_runtime_system();
     int read_size = av_audio_fifo_read(fifo, (void **)frame->data, frame_size);
+    caml_acquire_runtime_system();
+
     if (read_size < frame_size) {
-      Log("Failed to read data from audio FIFO");
-      return AVERROR_EXTERNAL;
+      return ocaml_avutil_raise_error(AVERROR_EXTERNAL);
     }
     frame->nb_samples = frame_size;
     frame->pts = ctx->pts;
@@ -528,17 +595,25 @@ static int send_audio_fifo_frame(codec_context_t *ctx)
     frame = NULL;
   }
 
+  caml_release_runtime_system();
   ret = avcodec_send_frame(ctx->codec_context, frame);
+  caml_acquire_runtime_system();
 
-  return ret;
+  if (ret < 0) ocaml_avutil_raise_error(ret);
 }
 
-static int send_frame(codec_context_t *ctx, AVFrame *frame)
+static inline int send_frame(codec_context_t *ctx, AVFrame *frame)
 {
   int ret;
   AVCodecContext * enc_ctx = ctx->codec_context;
 
-  if(!ctx->codec_context && !(enc_ctx = avcodec_open_codec(ctx, frame))) return AVERROR_EXTERNAL;
+  if(!ctx->codec_context) {
+    caml_release_runtime_system();
+    enc_ctx = avcodec_open_codec(ctx, frame);
+    caml_acquire_runtime_system();
+
+    if (!enc_ctx) Fail("Failed to open codec");
+  }
 
   ctx->flushed = ! frame;
 
@@ -546,7 +621,13 @@ static int send_frame(codec_context_t *ctx, AVFrame *frame)
     if(frame) {
       frame->pts = ctx->pts++;
     }
+    caml_release_runtime_system();
     ret = avcodec_send_frame(ctx->codec_context, frame);
+    caml_acquire_runtime_system();
+
+    if (ret == AVERROR(EAGAIN)) return ret;
+
+    if (ret < 0) ocaml_avutil_raise_error(ret);
   }
   else if(ctx->audio_fifo == NULL) {
 
@@ -555,7 +636,13 @@ static int send_frame(codec_context_t *ctx, AVFrame *frame)
       ctx->pts += frame->nb_samples;
     }
   
+    caml_release_runtime_system();
     ret = avcodec_send_frame(ctx->codec_context, frame);
+    caml_acquire_runtime_system();
+
+    if (ret == AVERROR(EAGAIN)) return ret;
+
+    if (ret < 0) ocaml_avutil_raise_error(ret);
   }
   else {
     if(frame != NULL) {
@@ -564,19 +651,25 @@ static int send_frame(codec_context_t *ctx, AVFrame *frame)
 
       fifo_size += frame->nb_samples;
     
+      caml_release_runtime_system();
       ret = av_audio_fifo_realloc(fifo, fifo_size);
-      if (ret < 0) return ret;
+      caml_acquire_runtime_system();
+
+      if (ret < 0) ocaml_avutil_raise_error(ret);
 
       // Store the new samples in the FIFO buffer.
+      caml_release_runtime_system();
       ret = av_audio_fifo_write(fifo, (void **)(const uint8_t**)frame->extended_data, frame->nb_samples);
-      if (ret < frame->nb_samples) {
-        Log("Failed to write data to audio FIFO");
-        return AVERROR_EXTERNAL;
-      }
+      caml_acquire_runtime_system();
+
+      if (ret == AVERROR(EAGAIN)) return ret;
+
+      if (ret < frame->nb_samples) Fail("Invalid number of samples written to audio fifo queue");
     }
-    ret = send_audio_fifo_frame(ctx);
+    send_audio_fifo_frame(ctx);
   }
-  return ret;
+
+  return 0;
 }
 
 CAMLprim value ocaml_avcodec_send_frame(value _ctx, value _frame)
@@ -586,13 +679,7 @@ CAMLprim value ocaml_avcodec_send_frame(value _ctx, value _frame)
   codec_context_t *ctx = CodecContext_val(_ctx);
   AVFrame *frame = _frame ? Frame_val(_frame) : NULL;
 
-  caml_release_runtime_system();
   int ret = send_frame(ctx, frame);
-  caml_acquire_runtime_system();
-
-  if(ret == AVERROR_EXTERNAL) Raise(EXN_FAILURE, "%s", ocaml_av_error_msg);
-
-  if(ret < 0 && ret != AVERROR_EOF && ret != AVERROR(EAGAIN)) Raise(EXN_FAILURE, "Failed to send frame for encoding : %s", av_err2str(ret));
 
   if (ret == AVERROR(EAGAIN)) ans = PVV_Again;
   else ans = PVV_Ok;
@@ -609,24 +696,29 @@ CAMLprim value ocaml_avcodec_receive_packet(value _ctx)
   int ret = 0;
 
   caml_release_runtime_system();
-
   AVPacket *packet = av_packet_alloc();
+  caml_acquire_runtime_system();
+
+  if (!packet) caml_raise_out_of_memory();
 
   for (; packet && ret >= 0;) {
+    caml_release_runtime_system();
     ret = avcodec_receive_packet(ctx->codec_context, packet);
+    caml_acquire_runtime_system();
 
     if(ret == AVERROR(EAGAIN) && ctx->audio_fifo) {
-      ret = send_audio_fifo_frame(ctx);
+      send_audio_fifo_frame(ctx);
     }
     else break;
   }
-  caml_acquire_runtime_system();
 
-  if( ! packet) Raise(EXN_FAILURE, "Failed to allocate packet");
   if (ret < 0) {
+    caml_release_runtime_system();
     av_packet_free(&packet);
+    caml_acquire_runtime_system();
+
     if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) ans = Val_int(0);
-    else Raise(EXN_FAILURE, "Failed to receive packet from frame : %s", av_err2str(ret));
+    else ocaml_avutil_raise_error(ret);
   }
   else {
     ans = caml_alloc(1, 0);
@@ -647,7 +739,7 @@ CAMLprim value ocaml_avcodec_flush_encoder(value _ctx) {
 static enum AVCodecID find_codec_id(const char *name)
 {
   AVCodec * codec = avcodec_find_encoder_by_name(name);
-  if( ! codec) Raise(EXN_FAILURE, "Failed to find %s codec", name);
+  if( ! codec) ocaml_avutil_raise_error(AVERROR_ENCODER_NOT_FOUND);
 
   return codec->id;
 }

--- a/src/avcodec_stubs.h
+++ b/src/avcodec_stubs.h
@@ -15,10 +15,7 @@ void value_of_codec_parameters_copy(AVCodecParameters *src, value * pvalue);
 
 #define Packet_val(v) (*(struct AVPacket**)Data_custom_val(v))
 
-void value_of_packet(AVPacket *packet, value * pvalue);
-
-AVPacket * alloc_packet_value(value * pvalue);
-
+value value_of_ffmpeg(AVPacket *packet);
 
 /**** Audio codec ID ****/
 

--- a/src/avdevice.ml
+++ b/src/avdevice.ml
@@ -1,5 +1,9 @@
 open Avutil
 
+external init : unit -> unit = "ocaml_avdevice_init" [@@noalloc]
+
+let () = init ()
+
 external get_audio_input_formats : unit -> (input, audio)format array = "ocaml_avdevice_get_audio_input_formats"
 let get_audio_input_formats() = Array.to_list ( get_audio_input_formats() )
 let get_default_audio_input_format() = List.hd(get_audio_input_formats())
@@ -19,7 +23,7 @@ let get_default_video_output_format() = List.hd(get_video_output_formats())
 
 let find_input name fmts =
   try List.find(fun d -> Av.Format.get_input_name d = name) fmts
-  with Not_found -> raise(Failure("Input device not found : " ^ name))
+  with Not_found -> raise (Error (`Failure("Input device not found : " ^ name)))
 
 let find_audio_input name = find_input name (get_audio_input_formats())
 
@@ -27,7 +31,7 @@ let find_video_input name = find_input name (get_video_input_formats())
 
 let find_output name fmts =
   try List.find(fun d -> Av.Format.get_output_name d = name) fmts
-  with Not_found -> raise(Failure("Output device not found : " ^ name))
+  with Not_found -> raise (Error (`Failure("Output device not found : " ^ name)))
 
 let find_audio_output name = find_output name (get_audio_output_formats())
 

--- a/src/avdevice.ml
+++ b/src/avdevice.ml
@@ -4,21 +4,25 @@ external init : unit -> unit = "ocaml_avdevice_init" [@@noalloc]
 
 let () = init ()
 
+let hd = function
+  | [] -> raise Not_found
+  | x::_ -> x
+
 external get_audio_input_formats : unit -> (input, audio)format array = "ocaml_avdevice_get_audio_input_formats"
 let get_audio_input_formats() = Array.to_list ( get_audio_input_formats() )
-let get_default_audio_input_format() = List.hd(get_audio_input_formats())
+let get_default_audio_input_format() = hd(get_audio_input_formats())
 
 external get_video_input_formats : unit -> (input, video)format array = "ocaml_avdevice_get_video_input_formats"
 let get_video_input_formats() = Array.to_list ( get_video_input_formats() )
-let get_default_video_input_format() = List.hd(get_video_input_formats())
+let get_default_video_input_format() = hd(get_video_input_formats())
 
 external get_audio_output_formats : unit -> (output, audio)format array = "ocaml_avdevice_get_audio_output_formats"
 let get_audio_output_formats() = Array.to_list ( get_audio_output_formats() )
-let get_default_audio_output_format() = List.hd(get_audio_output_formats())
+let get_default_audio_output_format() = hd(get_audio_output_formats())
 
 external get_video_output_formats : unit -> (output, video)format array = "ocaml_avdevice_get_video_output_formats"
 let get_video_output_formats() = Array.to_list ( get_video_output_formats() )
-let get_default_video_output_format() = List.hd(get_video_output_formats())
+let get_default_video_output_format() = hd(get_video_output_formats())
 
 
 let find_input name fmts =

--- a/src/avdevice.mli
+++ b/src/avdevice.mli
@@ -28,28 +28,28 @@ val get_default_video_output_format : unit -> (output, video)format
 
 
 val open_audio_input : string -> input container
-(** Open the audio input device from his name. @raise Failure if the device is not found. *)
+(** Open the audio input device from his name. @raise Error if the device is not found. *)
 
 val open_default_audio_input : unit -> input container
-(** Open the default audio input device from his name. @raise Failure if the device is not found. *)
+(** Open the default audio input device from his name. @raise Error if the device is not found. *)
 
 val open_video_input : string -> input container
-(** Open the video input device from his name. @raise Failure if the device is not found. *)
+(** Open the video input device from his name. @raise Error if the device is not found. *)
 
 val open_default_video_input : unit -> input container
-(** Open the default video input device from his name. @raise Failure if the device is not found. *)
+(** Open the default video input device from his name. @raise Error if the device is not found. *)
 
 val open_audio_output : string -> output container
-(** Open the audio output device from his name. @raise Failure if the device is not found. *)
+(** Open the audio output device from his name. @raise Error if the device is not found. *)
 
 val open_default_audio_output : unit -> output container
-(** Open the default audio output device from his name. @raise Failure if the device is not found. *)
+(** Open the default audio output device from his name. @raise Error if the device is not found. *)
 
 val open_video_output : string -> output container
-(** Open the video output device from his name. @raise Failure if the device is not found. *)
+(** Open the video output device from his name. @raise Error if the device is not found. *)
 
 val open_default_video_output : unit -> output container
-(** Open the default video output device from his name. @raise Failure if the device is not found. *)
+(** Open the default video output device from his name. @raise Error if the device is not found. *)
 
 
 (** Application to device communication *)
@@ -70,7 +70,7 @@ module App_to_dev : sig
   | Get_mute
 
   val control_messages : message list -> _ container -> unit
-  (** [Avdevice.App_to_dev.control_messages msg_list device] send the [msg_list] list of control message to the [device]. @raise Failure if the application to device control message failed. *)
+  (** [Avdevice.App_to_dev.control_messages msg_list device] send the [msg_list] list of control message to the [device]. @raise Error if the application to device control message failed. *)
 end
 
 (** Device to application communication *)

--- a/src/avutil.ml
+++ b/src/avutil.ml
@@ -32,6 +32,7 @@ type error = [
   | `Protocol_not_found
   | `Stream_not_found
   | `Bug
+  | `Eagain
   | `Unknown
   | `Experimental
   | `Failure of string

--- a/src/avutil.mli
+++ b/src/avutil.mli
@@ -46,6 +46,7 @@ type error = [
   | `Protocol_not_found
   | `Stream_not_found
   | `Bug
+  | `Eagain
   | `Unknown
   | `Experimental
 (* `Failure is for errors from the binding code itself. *)

--- a/src/avutil.mli
+++ b/src/avutil.mli
@@ -30,9 +30,31 @@ type 'media frame
 
 (** {1 Exception} *)
 
-(** A failure occured (with given explanation). *)
-exception Failure of string
+(** Internal errors. *)
+type error = [
+  | `Bsf_not_found
+  | `Decoder_not_found
+  | `Demuxer_not_found
+  | `Encoder_not_found
+  | `Eof
+  | `Exit
+  | `Filter_not_found
+  | `Invalid_data
+  | `Muxer_not_found
+  | `Option_not_found
+  | `Patch_welcome
+  | `Protocol_not_found
+  | `Stream_not_found
+  | `Bug
+  | `Unknown
+  | `Experimental
+(* `Failure is for errors from the binding code itself. *)
+  | `Failure of string
+]
 
+exception Error of error
+
+val string_of_error : error -> string
 
 type data = (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
@@ -120,7 +142,7 @@ module Pixel_format : sig
   (** [Pixel_format.to_string f] Return a string representation of the pixel format [f]. *)
   val to_string : t -> string
 
-  (** [Pixel_format.of_string s] Convert the string [s] into a [Pixel_format.t]. @raise Failure if [s] is not a valid format. *)
+  (** [Pixel_format.of_string s] Convert the string [s] into a [Pixel_format.t]. @raise Error if [s] is not a valid format. *)
   val of_string : string -> t
 end
 
@@ -128,13 +150,13 @@ module Video : sig
   type planes = (data * int) array
 
   val create_frame : int -> int -> Pixel_format.t -> video frame
-  (** [Avutil.Video.create_frame w h pf] create a video frame with [w] width, [h] height and [pf] pixel format. @raise Failure if the allocation failed. *)
+  (** [Avutil.Video.create_frame w h pf] create a video frame with [w] width, [h] height and [pf] pixel format. @raise Error if the allocation failed. *)
 
   val frame_get_linesize : video frame -> int -> int
-  (** [Avutil.Video.frame_get_linesize vf n] return the line size of the [n] plane of the [vf] video frame. @raise Failure if [n] is out of boundaries. *)
+  (** [Avutil.Video.frame_get_linesize vf n] return the line size of the [n] plane of the [vf] video frame. @raise Error if [n] is out of boundaries. *)
 
   val frame_visit : make_writable:bool -> (planes -> unit) -> video frame -> video frame
-  (** [Avutil.Video.frame_visit ~make_writable:wrt f vf] call the [f] function with planes wrapping the [vf] video frame data. The make_writable:[wrt] parameter must be set to true if the [f] function writes in the planes. Access to the frame through the planes is safe as long as it occurs in the [f] function and the frame is not sent to an encoder. The same frame is returned for convenience. @raise Failure if the make frame writable operation failed. *)
+  (** [Avutil.Video.frame_visit ~make_writable:wrt f vf] call the [f] function with planes wrapping the [vf] video frame data. The make_writable:[wrt] parameter must be set to true if the [f] function writes in the planes. Access to the frame through the planes is safe as long as it occurs in the [f] function and the frame is not sent to an encoder. The same frame is returned for convenience. @raise Error if the make frame writable operation failed. *)
 end
 
 
@@ -146,7 +168,7 @@ module Subtitle : sig
   (** Return the time base for subtitles. *)
 
   val create_frame : float -> float -> string list -> subtitle frame
-  (** [Avutil.Subtitle.create_frame start end lines] create a subtitle frame from [lines] which is displayed at [start] time and hidden at [end] time in seconds. @raise Failure if the allocation failed. *)
+  (** [Avutil.Subtitle.create_frame start end lines] create a subtitle frame from [lines] which is displayed at [start] time and hidden at [end] time in seconds. @raise Error if the allocation failed. *)
 
   val frame_to_lines : subtitle frame -> (float * float * string list)
   (** Convert subtitle frame to lines. The two float are the start and the end dislpay time in seconds. *)

--- a/src/avutil_stubs.c
+++ b/src/avutil_stubs.c
@@ -134,7 +134,8 @@ CAMLprim value ocaml_avutil_string_of_error(value error) {
       err = AVERROR_EXPERIMENTAL;
       break;
     default:
-      caml_failwith("Invalid error!");
+      // Failure error is a 2-uple with string as second entry.
+      CAMLreturn(Field(error,1));
   }
 
   CAMLreturn(caml_copy_string(av_err2str(err)));

--- a/src/avutil_stubs.c
+++ b/src/avutil_stubs.c
@@ -19,9 +19,126 @@
 #include "channel_layout_stubs.h"
 #include "sample_format_stubs.h"
 
-char ocaml_av_error_msg[ERROR_MSG_SIZE + 1];
 char ocaml_av_exn_msg[ERROR_MSG_SIZE + 1];
 
+void ocaml_avutil_raise_error(int err) {
+  int _err = 0;
+
+  switch (err) {
+    case AVERROR_BSF_NOT_FOUND:
+      _err = PVV_Bsf_not_found;
+      break;
+    case AVERROR_DECODER_NOT_FOUND:
+      _err = PVV_Decoder_not_found;
+      break;
+    case AVERROR_DEMUXER_NOT_FOUND:
+      _err = PVV_Demuxer_not_found;
+      break;
+    case AVERROR_ENCODER_NOT_FOUND:
+      _err = PVV_Encoder_not_found;
+      break;
+    case AVERROR_EOF:
+      _err = PVV_Eof;
+      break;
+    case AVERROR_EXIT:
+      _err = PVV_Exit;
+      break;
+    case AVERROR_FILTER_NOT_FOUND:
+      _err = PVV_Filter_not_found;
+      break;
+    case AVERROR_INVALIDDATA:
+      _err = PVV_Invalid_data;
+      break;
+    case AVERROR_MUXER_NOT_FOUND:
+      _err = PVV_Muxer_not_found;
+      break;
+    case AVERROR_OPTION_NOT_FOUND:
+      _err = PVV_Option_not_found;
+      break;
+    case AVERROR_PATCHWELCOME:
+      _err = PVV_Patch_welcome;
+      break;
+    case AVERROR_PROTOCOL_NOT_FOUND:
+      _err = PVV_Protocol_not_found;
+      break;
+    case AVERROR_STREAM_NOT_FOUND:
+      _err = PVV_Stream_not_found;
+      break;
+    case AVERROR_BUG:
+      _err = PVV_Bug;
+      break;
+    case AVERROR_UNKNOWN:
+      _err = PVV_Unknown;
+      break;
+    case AVERROR_EXPERIMENTAL:
+      _err = PVV_Experimental;
+      break;
+    default:
+      Fail("%s", av_err2str(err));
+  }
+
+  caml_raise_with_arg(*caml_named_value(EXN_ERROR), _err);
+}
+
+CAMLprim value ocaml_avutil_string_of_error(value error) {
+  CAMLparam0();
+  int err;
+
+  switch (error) {
+    case PVV_Bsf_not_found:
+      err = AVERROR_BSF_NOT_FOUND;
+      break;
+    case PVV_Decoder_not_found:
+      err = AVERROR_DECODER_NOT_FOUND;
+      break;
+    case PVV_Demuxer_not_found:
+      err = AVERROR_DEMUXER_NOT_FOUND;
+      break;
+    case PVV_Encoder_not_found:
+      err = AVERROR_ENCODER_NOT_FOUND;
+      break;
+    case PVV_Eof:
+      err = AVERROR_EOF;
+      break;
+    case PVV_Exit:
+      err = AVERROR_EXIT;
+      break;
+    case PVV_Filter_not_found:
+      err = AVERROR_FILTER_NOT_FOUND;
+      break;
+    case PVV_Invalid_data:
+      err = AVERROR_INVALIDDATA;
+      break;
+    case PVV_Muxer_not_found:
+      err = AVERROR_MUXER_NOT_FOUND;
+      break;
+    case PVV_Option_not_found:
+      err = AVERROR_OPTION_NOT_FOUND;
+      break;
+    case PVV_Patch_welcome:
+      err = AVERROR_PATCHWELCOME;
+      break;
+    case PVV_Protocol_not_found:
+      err = AVERROR_PROTOCOL_NOT_FOUND;
+      break;
+    case PVV_Stream_not_found:
+      err = AVERROR_STREAM_NOT_FOUND;
+      break;
+    case PVV_Bug:
+      err = AVERROR_BUG;
+      break;
+    case PVV_Unknown:
+      err = AVERROR_UNKNOWN;
+      break;
+    case PVV_Experimental:
+      err = AVERROR_EXPERIMENTAL;
+      break;
+    default:
+      caml_failwith("Invalid error!");
+  }
+
+  CAMLreturn(caml_copy_string(av_err2str(err)));
+}
 
 /***** Global initialisation *****/
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
@@ -49,8 +166,9 @@ static int lock_manager(void **mtx, enum AVLockOp op)
   return 1;
 }
 
-value ocaml_avutil_register_lock_manager(value unit)
+CAMLprim value ocaml_avutil_register_lock_manager(value unit)
 {
+  CAMLparams0();
   static int registering_done = 0;
   static pthread_mutex_t registering_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -59,18 +177,17 @@ value ocaml_avutil_register_lock_manager(value unit)
 
     if( ! registering_done) {
 
+      caml_release_runtime_system();
       int ret = av_lockmgr_register(lock_manager);
+      caml_acquire_runtime_system();
 
-      if(ret < 0) {
-        Log("Failed to register lock manager : %s", av_err2str(ret));
-      }
-      else {
+      if(ret >= 0) {
         registering_done = 1;
       }
       pthread_mutex_unlock(&registering_mutex);
     }
   }
-  return Val_int(registering_done);
+  CAMLreturn(Val_int(registering_done));
 }
 #else
 value ocaml_avutil_register_lock_manager(value unit) { return Val_true; }
@@ -164,7 +281,9 @@ CAMLprim value ocaml_avutil_set_log_callback(value callback)
     caml_modify_generational_global_root(&ocaml_log_callback,callback);
   }
 
+  caml_release_runtime_system();
   av_log_set_callback(&av_log_ocaml_callback);
+  caml_acquire_runtime_system();
 
   CAMLreturn(Val_unit);
 }
@@ -178,7 +297,9 @@ CAMLprim value ocaml_avutil_clear_log_callback()
     ocaml_log_callback = (value)NULL;
   }
 
+  caml_release_runtime_system();
   av_log_set_callback(&av_log_default_callback);
+  caml_acquire_runtime_system();
 
   CAMLreturn(Val_unit);
 }
@@ -254,7 +375,10 @@ CAMLprim value ocaml_avutil_get_sample_fmt_name(value _sample_fmt)
   CAMLparam1(_sample_fmt);
   CAMLlocal1(ans);
 
+  caml_release_runtime_system();
   const char *name = av_get_sample_fmt_name(SampleFormat_val(_sample_fmt));
+  caml_acquire_runtime_system();
+
   ans = caml_copy_string(name);
 
   CAMLreturn(ans);
@@ -289,9 +413,12 @@ CAMLprim value ocaml_avutil_pixelformat_to_string(value pixel)
 CAMLprim value ocaml_avutil_pixelformat_of_string(value name)
 {
   CAMLparam1(name);
+ 
+  caml_release_runtime_system();
   enum AVPixelFormat p = av_get_pix_fmt(String_val(name));
+  caml_acquire_runtime_system();
 
-  if (p == AV_PIX_FMT_NONE) Raise(EXN_FAILURE, "Invalid format name");
+  if (p == AV_PIX_FMT_NONE) Fail( "Invalid format name");
 
   CAMLreturn(Val_PixelFormat(p));
 }
@@ -303,7 +430,10 @@ static void finalize_frame(value v)
 {
 #ifdef HAS_FRAME
   AVFrame *frame = Frame_val(v);
+
+  caml_release_runtime_system();
   if(frame) av_frame_free(&frame);
+  caml_acquire_runtime_system();
 #endif
 }
 
@@ -319,7 +449,7 @@ static struct custom_operations frame_ops =
 
 void value_of_frame(AVFrame *frame, value * pvalue)
 {
-  if( ! frame) Raise(EXN_FAILURE, "Empty frame");
+  if( ! frame) Fail( "Empty frame");
 
   *pvalue = caml_alloc_custom(&frame_ops, sizeof(AVFrame*), 0, 1);
   Frame_val((*pvalue)) = frame;
@@ -327,8 +457,11 @@ void value_of_frame(AVFrame *frame, value * pvalue)
 
 AVFrame * alloc_frame_value(value * pvalue)
 {
+  caml_release_runtime_system();
   AVFrame * frame = av_frame_alloc();
-  if( ! frame) Fail("Failed to allocate frame");
+  caml_acquire_runtime_system();
+
+  if( ! frame) caml_raise_out_of_memory();
 
   value_of_frame(frame, pvalue);
   return frame;
@@ -342,15 +475,20 @@ CAMLprim value ocaml_avutil_video_create_frame(value _w, value _h, value _format
 #ifndef HAS_FRAME
   caml_failwith("Not implemented.");
 #else
+  caml_release_runtime_system();
   AVFrame *frame = av_frame_alloc();
-  if( ! frame) Raise(EXN_FAILURE, "Failed to alloc video frame");
+  caml_acquire_runtime_system();
+  if( ! frame) caml_raise_out_of_memory();
 
   frame->format = PixelFormat_val(_format);
   frame->width  = Int_val(_w);
   frame->height = Int_val(_h);
 
+  caml_release_runtime_system();
   int ret = av_frame_get_buffer(frame, 32);
-  if(ret < 0) Raise(EXN_FAILURE, "Failed to alloc video frame buffer : %s", av_err2str(ret));
+  caml_acquire_runtime_system();
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   value_of_frame(frame, &ans);
 #endif
@@ -364,7 +502,7 @@ CAMLprim value ocaml_avutil_video_frame_get_linesize(value _frame, value _line)
   AVFrame *frame = Frame_val(_frame);
   int line = Int_val(_line);
 
-  if(line < 0 || line >= AV_NUM_DATA_POINTERS || ! frame->data[line]) Raise(EXN_FAILURE, "Failed to get linesize from video frame : line (%d) out of boundaries", line);
+  if(line < 0 || line >= AV_NUM_DATA_POINTERS || ! frame->data[line]) Fail( "Failed to get linesize from video frame : line (%d) out of boundaries", line);
 
   CAMLreturn(Val_int(frame->linesize[line]));
 #else
@@ -384,12 +522,18 @@ CAMLprim value ocaml_avutil_video_get_frame_bigarray_planes(value _frame, value 
   int i;
 
   if(Bool_val(_make_writable)) {
+    caml_release_runtime_system();
     int ret = av_frame_make_writable(frame);
-    if (ret < 0) Raise(EXN_FAILURE, "Failed to make frame writable : %s", av_err2str(ret));
+    caml_acquire_runtime_system();
+
+    if (ret < 0) ocaml_avutil_raise_error(ret);
   }
 
+  caml_release_runtime_system();
   int nb_planes = av_pix_fmt_count_planes((enum AVPixelFormat)frame->format);
-  if(nb_planes < 0) Raise(EXN_FAILURE, "Failed to get frame planes count : %s", av_err2str(nb_planes));
+  caml_acquire_runtime_system();
+
+  if(nb_planes < 0) ocaml_avutil_raise_error(nb_planes);
   
   ans = caml_alloc_tuple(nb_planes);
 
@@ -412,7 +556,10 @@ static void finalize_subtitle(value v)
 {
   struct AVSubtitle *subtitle = Subtitle_val(v);
 
+  caml_release_runtime_system();
   avsubtitle_free(subtitle);
+  caml_acquire_runtime_system();
+
   free(subtitle);
 }
 
@@ -428,7 +575,7 @@ static struct custom_operations subtitle_ops =
 
 void value_of_subtitle(AVSubtitle *subtitle, value * pvalue)
 {
-  if( ! subtitle) Raise(EXN_FAILURE, "Empty subtitle");
+  if( ! subtitle) Fail( "Empty subtitle");
 
   *pvalue = caml_alloc_custom(&subtitle_ops, sizeof(AVSubtitle*), 0, 1);
   Subtitle_val((*pvalue)) = subtitle;
@@ -437,7 +584,7 @@ void value_of_subtitle(AVSubtitle *subtitle, value * pvalue)
 AVSubtitle * alloc_subtitle_value(value * pvalue)
 {
   AVSubtitle * subtitle = (AVSubtitle*)calloc(1, sizeof(AVSubtitle));
-  if( ! subtitle) Fail("Failed to allocate subtitle");
+  if( ! subtitle) caml_raise_out_of_memory();
 
   value_of_subtitle(subtitle, pvalue);
 
@@ -458,7 +605,7 @@ CAMLprim value ocaml_avutil_subtitle_create_frame(value _start_time, value _end_
   int nb_lines = Wosize_val(_lines);
 
   AVSubtitle * subtitle = (AVSubtitle*)calloc(1, sizeof(AVSubtitle));
-  if( ! subtitle) Raise(EXN_FAILURE, "Failed to allocate subtitle frame");
+  if( ! subtitle) caml_raise_out_of_memory();
 
   value_of_subtitle(subtitle, &ans);
 
@@ -466,24 +613,31 @@ CAMLprim value ocaml_avutil_subtitle_create_frame(value _start_time, value _end_
   subtitle->end_display_time = (uint32_t)end_time;
   subtitle->pts = start_time;
 
+  caml_release_runtime_system();
   subtitle->rects = (AVSubtitleRect **)av_malloc_array(nb_lines, sizeof(AVSubtitleRect *));
-  if( ! subtitle->rects) Raise(EXN_FAILURE, "Failed to allocate subtitle frame");
+  caml_acquire_runtime_system();
+
+  if( ! subtitle->rects) caml_raise_out_of_memory();
 
   subtitle->num_rects = nb_lines;
   
   int i;
   for(i = 0; i < nb_lines; i++) {
     const char * text = String_val(Field(_lines, i));
+    
+    caml_release_runtime_system();
     subtitle->rects[i] = (AVSubtitleRect *)av_mallocz(sizeof(AVSubtitleRect));
-    if( ! subtitle->rects[i]) Raise(EXN_FAILURE, "Failed to allocate subtitle frame");
+    caml_acquire_runtime_system();
+  
+    if( ! subtitle->rects[i]) caml_raise_out_of_memory();
 
     subtitle->rects[i]->type = SUBTITLE_TEXT;
     subtitle->rects[i]->text = strdup(text);
-    if( ! subtitle->rects[i]->text) Raise(EXN_FAILURE, "Failed to allocate subtitle frame");
+    if( ! subtitle->rects[i]->text) caml_raise_out_of_memory();
 
     //    subtitle->rects[i]->type = SUBTITLE_ASS;
     //    subtitle->rects[i]->ass = get_dialog(i + 1, 0, NULL, NULL, text);
-    //    if( ! subtitle->rects[i]->ass) Raise(EXN_FAILURE, "Failed to allocate subtitle frame");
+    //    if( ! subtitle->rects[i]->ass) Fail( "Failed to allocate subtitle frame");
   }
 
   CAMLreturn(ans);

--- a/src/avutil_stubs.h
+++ b/src/avutil_stubs.h
@@ -86,17 +86,12 @@ value Val_PixelFormat(enum AVPixelFormat pf);
 
 #define Frame_val(v) (*(struct AVFrame**)Data_custom_val(v))
 
-void value_of_frame(AVFrame *frame, value * pvalue);
-
-AVFrame * alloc_frame_value(value * pvalue);
-
+value value_of_frame(AVFrame *frame);
 
 /***** AVSubtitle *****/
 #define Subtitle_val(v) (*(struct AVSubtitle**)Data_custom_val(v))
 
-void value_of_subtitle(AVSubtitle *subtitle, value * pvalue);
-
-AVSubtitle * alloc_subtitle_value(value * pvalue);
+value value_of_subtitle(AVSubtitle *subtitle);
 
 int subtitle_header_default(AVCodecContext *avctx);
 

--- a/src/avutil_stubs.h
+++ b/src/avutil_stubs.h
@@ -20,23 +20,16 @@
 #include "polymorphic_variant_values_stubs.h"
 
 #define ERROR_MSG_SIZE 256
-#define EXN_FAILURE "ffmpeg_exn_failure"
+#define EXN_ERROR "ffmpeg_exn_error"
 
-#define Log(...) snprintf(ocaml_av_error_msg, ERROR_MSG_SIZE, __VA_ARGS__)
-
-#define Fail(...) {                                             \
-    snprintf(ocaml_av_error_msg, ERROR_MSG_SIZE, __VA_ARGS__);  \
-    return NULL;                                                \
-  }
-
-#define Raise(exn, ...) {                                               \
+#define Fail(...) {                                               \
     snprintf(ocaml_av_exn_msg, ERROR_MSG_SIZE, __VA_ARGS__);            \
-    caml_raise_with_string(*caml_named_value(exn), (ocaml_av_exn_msg)); \
+    caml_callback(*caml_named_value("ffmpeg_exn_failure"), caml_copy_string(ocaml_av_exn_msg)); \
   }
 
-extern char ocaml_av_error_msg[];
-extern char ocaml_av_exn_msg[];
+void ocaml_avutil_raise_error(int err);
 
+extern char ocaml_av_exn_msg[];
 
 #define List_init(list) (list) = Val_emptylist
 

--- a/src/gen_code.ml
+++ b/src/gen_code.ml
@@ -117,8 +117,13 @@ let () =
 
   List.iter(print_define_polymorphic_variant_value pvv_oc)
     ["Audio"; "Video"; "Subtitle"; "Packet"; "Frame";
-     "Ok"; "Again"; "End_of_file"; "Error";
-     "Second"; "Millisecond"; "Microsecond"; "Nanosecond"];
+     "Ok"; "Again"; "End_of_file";
+     "Second"; "Millisecond"; "Microsecond"; "Nanosecond";
+     (* Errors *)
+     "Bsf_not_found"; "Decoder_not_found"; "Demuxer_not_found";
+     "Encoder_not_found"; "Eof"; "Exit"; "Filter_not_found"; "Invalid_data";
+     "Muxer_not_found"; "Option_not_found"; "Patch_welcome"; "Protocol_not_found";
+     "Stream_not_found"; "Bug"; "Unknown"; "Experimental"; "Failure"];
 
   close_out pvv_oc;
 

--- a/src/gen_code.ml
+++ b/src/gen_code.ml
@@ -117,13 +117,12 @@ let () =
 
   List.iter(print_define_polymorphic_variant_value pvv_oc)
     ["Audio"; "Video"; "Subtitle"; "Packet"; "Frame";
-     "Ok"; "Again"; "End_of_file";
-     "Second"; "Millisecond"; "Microsecond"; "Nanosecond";
+     "Ok"; "Again"; "Second"; "Millisecond"; "Microsecond"; "Nanosecond";
      (* Errors *)
      "Bsf_not_found"; "Decoder_not_found"; "Demuxer_not_found";
      "Encoder_not_found"; "Eof"; "Exit"; "Filter_not_found"; "Invalid_data";
      "Muxer_not_found"; "Option_not_found"; "Patch_welcome"; "Protocol_not_found";
-     "Stream_not_found"; "Bug"; "Unknown"; "Experimental"; "Failure"];
+     "Stream_not_found"; "Bug"; "Eagain"; "Unknown"; "Experimental"; "Failure"];
 
   close_out pvv_oc;
 

--- a/src/swresample.ml
+++ b/src/swresample.ml
@@ -175,12 +175,12 @@ module Make (I : AudioData) (O : AudioData) = struct
     let in_sample_format = match in_sample_format with
       | _ when I.sf <> `None -> I.sf
       | Some sf -> sf
-      | _ -> raise(Failure "Swresample input sample format undefined")
+      | _ -> raise (Error (`Failure "Swresample input sample format undefined"))
     in
     let out_sample_format = match out_sample_format with
       | _ when O.sf <> `None -> O.sf
       | Some sf -> sf
-      | _ -> raise(Failure "Swresample output sample format undefined")
+      | _ -> raise (Error (`Failure "Swresample output sample format undefined"))
     in
     create I.vk in_channel_layout in_sample_format in_sample_rate
       O.vk out_channel_layout out_sample_format out_sample_rate opts

--- a/src/swresample.mli
+++ b/src/swresample.mli
@@ -25,7 +25,7 @@ module Make (I : AudioData) (O : AudioData) : sig
   val create : ?options:options list -> Channel_layout.t -> ?in_sample_format:Sample_format.t -> int -> Channel_layout.t -> ?out_sample_format:Sample_format.t -> int -> t
   (** [Swresample.create in_cl ~in_sample_format:in_sf in_sr out_cl ~out_sample_format:out_sf out_sr] create a Swresample.t with [in_cl] channel layout, [in_sf] sample format and [in_sr] sample rate as input format and [out_cl] channel layout, [out_sf] sample format and [out_sr] sample rate as output format.
 If a sample format parameter is not provided, the sample format defined by the associated AudioData module is used.
-@raise Failure "Swresample input/output sample format undefined" if a sample format parameter is not provided and the associated AudioData module does not define a sample format as is the case for Bytes and Frame. *)
+@raise Error "Swresample input/output sample format undefined" if a sample format parameter is not provided and the associated AudioData module does not define a sample format as is the case for Bytes and Frame. *)
 
   val from_codec : ?options:options list -> audio Avcodec.t -> Channel_layout.t -> ?out_sample_format:Sample_format.t -> int -> t
   (** [Swresample.from_codec in_ac out_cl ~out_sample_format:out_sf out_sr] do the same as {!Swresample.create} with the [in_ac] audio codec properties as input format. *)
@@ -43,7 +43,7 @@ If a sample format parameter is not provided, the sample format defined by the a
 
   val convert : t -> I.t -> O.t
   (** [Swresample.convert rsp iad] resample and convert the [iad] input audio data to the output audio data according to the [rsp] resampler context format.
-@raise Failure if the conversion failed. *)
+@raise Error if the conversion failed. *)
 end
 
     

--- a/src/swresample_stubs.c
+++ b/src/swresample_stubs.c
@@ -44,40 +44,47 @@ struct swr_t {
   int release_out_vector;
 
   int (*get_in_samples)(swr_t *, value *);
-  int (*convert)(swr_t *, int, int);
+  void (*convert)(swr_t *, int, int);
 };
 
 #define Swr_val(v) (*(swr_t**)Data_custom_val(v))
 
-static int alloc_data(struct audio_t * audio, int nb_samples)
+static inline void alloc_data(struct audio_t * audio, int nb_samples)
 {
   if(audio->data != NULL && audio->data[0] != NULL) {
+    caml_release_runtime_system();
     av_freep(&audio->data[0]);
+    caml_acquire_runtime_system();
+
     audio->nb_samples = 0;
   }
 
   audio->owns_data = 1;
 
+  caml_release_runtime_system();
   int ret = av_samples_alloc(audio->data, NULL, audio->nb_channels,
                              nb_samples, audio->sample_fmt, 0);
-  if(ret < 0) return ret;
+  caml_acquire_runtime_system();
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   audio->nb_samples = nb_samples;
-  return ret;
 }
 
 static int get_in_samples_frame(swr_t *swr, value *in_vector)
 {
   AVFrame *frame = Frame_val(*in_vector);
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 0, 100)
+  caml_release_runtime_system();
   int nb_channels = av_frame_get_channels(frame);
+  caml_acquire_runtime_system();
 #else
   int nb_channels = frame->channels;
 #endif
     
-  if(nb_channels != swr->in.nb_channels) Raise(EXN_FAILURE, "Swresample failed to convert %d channels : %d channels were expected", nb_channels, swr->in.nb_channels);
+  if(nb_channels != swr->in.nb_channels) Fail( "Swresample failed to convert %d channels : %d channels were expected", nb_channels, swr->in.nb_channels);
 
-  if(frame->format != swr->in.sample_fmt) Raise(EXN_FAILURE, "Swresample failed to convert %s sample format : %s sample format were expected", av_get_sample_fmt_name(frame->format), av_get_sample_fmt_name(swr->in.sample_fmt));
+  if(frame->format != swr->in.sample_fmt) Fail( "Swresample failed to convert %s sample format : %s sample format were expected", av_get_sample_fmt_name(frame->format), av_get_sample_fmt_name(swr->in.sample_fmt));
 
   swr->in.data = frame->extended_data;
 
@@ -89,10 +96,8 @@ static int get_in_samples_string(swr_t *swr, value *in_vector)
   int str_len = caml_string_length(*in_vector);
   int nb_samples = str_len / (swr->in.bytes_per_samples * swr->in.nb_channels);
 
-  if(nb_samples > swr->in.nb_samples) {
-    int ret = alloc_data(&swr->in, nb_samples);
-    if (ret < 0) return ret;
-  }
+  if(nb_samples > swr->in.nb_samples)
+    alloc_data(&swr->in, nb_samples);
 
   memcpy(swr->in.data[0], (uint8_t*)String_val(*in_vector), str_len);
 
@@ -106,15 +111,13 @@ static int get_in_samples_planar_string(swr_t *swr, value *in_vector)
   int str_len = caml_string_length(Field(*in_vector, 0));
   int i, nb_samples = str_len / swr->in.bytes_per_samples;
 
-  if(nb_samples > swr->in.nb_samples) {
-    int ret = alloc_data(&swr->in, nb_samples);
-    if (ret < 0) return ret;
-  }
+  if(nb_samples > swr->in.nb_samples)
+    alloc_data(&swr->in, nb_samples);
 
   for (i = 0; i < swr->in.nb_channels; i++) {
     str = Field(*in_vector, i);
     
-    if(str_len != caml_string_length(str)) Raise(EXN_FAILURE, "Swresample failed to convert channel %d's %lu bytes : %d bytes were expected", i, caml_string_length(str), str_len);
+    if(str_len != caml_string_length(str)) Fail( "Swresample failed to convert channel %d's %lu bytes : %d bytes were expected", i, caml_string_length(str), str_len);
 
     memcpy(swr->in.data[i], (uint8_t*)String_val(str), str_len);
   }
@@ -126,10 +129,8 @@ static int get_in_samples_float_array(swr_t *swr, value *in_vector)
   int i, linesize = Wosize_val(*in_vector) / Double_wosize;
   int nb_samples = linesize / swr->in.nb_channels;
 
-  if(nb_samples > swr->in.nb_samples) {
-    int ret = alloc_data(&swr->in, nb_samples);
-    if (ret < 0) return ret;
-  }
+  if(nb_samples > swr->in.nb_samples)
+    alloc_data(&swr->in, nb_samples);
 
   double * pcm = (double*)swr->in.data[0];
   
@@ -147,15 +148,13 @@ static int get_in_samples_planar_float_array(swr_t *swr, value *in_vector)
   int i, j, nb_words = Wosize_val(Field(*in_vector, 0));
   int nb_samples = nb_words / Double_wosize;
 
-  if(nb_samples > swr->in.nb_samples) {
-    int ret = alloc_data(&swr->in, nb_samples);
-    if (ret < 0) return ret;
-  }
+  if(nb_samples > swr->in.nb_samples)
+    alloc_data(&swr->in, nb_samples);
 
   for (i = 0; i < swr->in.nb_channels; i++) {
     fa = Field(*in_vector, i);
     
-    if(nb_words != Wosize_val(fa)) Raise(EXN_FAILURE, "Swresample failed to convert channel %d's %lu bytes : %d bytes were expected", i, Wosize_val(fa), nb_words);
+    if(nb_words != Wosize_val(fa)) Fail( "Swresample failed to convert channel %d's %lu bytes : %d bytes were expected", i, Wosize_val(fa), nb_words);
 
     double * pcm = (double*)swr->in.data[i];
     
@@ -181,7 +180,7 @@ static int get_in_samples_planar_ba(swr_t *swr, value *in_vector)
   for (int i = 0; i < swr->in.nb_channels; i++) {
     ba = Field(*in_vector, i);
     
-    if(nb_samples != Caml_ba_array_val(ba)->dim[0]) Raise(EXN_FAILURE, "Swresample failed to convert channel %d's %ld bytes : %d bytes were expected", i, Caml_ba_array_val(ba)->dim[0], nb_samples);
+    if(nb_samples != Caml_ba_array_val(ba)->dim[0]) Fail( "Swresample failed to convert channel %d's %ld bytes : %d bytes were expected", i, Caml_ba_array_val(ba)->dim[0], nb_samples);
 
     swr->in.data[i] = Caml_ba_data_val(ba);
   }
@@ -189,65 +188,68 @@ static int get_in_samples_planar_ba(swr_t *swr, value *in_vector)
 }
 
 
-static int alloc_out_frame(swr_t *swr, int nb_samples)
+static void alloc_out_frame(swr_t *swr, int nb_samples)
 {
   CAMLparam0();
   CAMLlocal1(vector);
+  int ret;
   
+  caml_release_runtime_system();
   AVFrame * frame = av_frame_alloc();
+  caml_acquire_runtime_system();
 
-  if( ! frame) Raise(EXN_FAILURE, "Failed to allocate resampling output frame");
+  if( ! frame) caml_raise_out_of_memory();
 
   frame->nb_samples     = nb_samples;
   frame->channel_layout = swr->out_channel_layout;
   frame->format         = swr->out.sample_fmt;
   frame->sample_rate    = swr->out_sample_rate;
 
-  int ret = av_frame_get_buffer(frame, 0);
+  caml_release_runtime_system();
+  ret = av_frame_get_buffer(frame, 0);
 
   if (ret < 0) {
     av_frame_free(&frame);
+    caml_acquire_runtime_system();
+    ocaml_avutil_raise_error(ret);
   }
-  else {
-    value_of_frame(frame, &vector);
-    caml_modify_generational_global_root(&swr->out_vector, vector);
-    swr->out.data = frame->extended_data;
-    swr->out.nb_samples = nb_samples;
-  }
-  CAMLreturnT(int, ret);
+
+  caml_acquire_runtime_system();
+
+  value_of_frame(frame, &vector);
+  caml_modify_generational_global_root(&swr->out_vector, vector);
+  swr->out.data = frame->extended_data;
+  swr->out.nb_samples = nb_samples;
 }
 
-static int convert_to_frame(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_frame(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples || swr->release_out_vector) {
-    int ret = alloc_out_frame(swr, out_nb_samples);
-    if(ret < 0) return ret;
-  }
+  if (out_nb_samples > swr->out.nb_samples || swr->release_out_vector)
+    alloc_out_frame(swr, out_nb_samples);
 
   caml_release_runtime_system();
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   Frame_val(swr->out_vector)->nb_samples = ret;
-  return ret;
 }
 
-static int convert_to_string(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_string(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples) {
-    int ret = alloc_data(&swr->out, out_nb_samples);
-    if(ret < 0) return ret;
-  }
+  if (out_nb_samples > swr->out.nb_samples)
+    alloc_data(&swr->out, out_nb_samples);
 
   caml_release_runtime_system();
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   size_t len = ret * swr->out.nb_channels * swr->out.bytes_per_samples;
 
@@ -257,23 +259,20 @@ static int convert_to_string(swr_t *swr, int in_nb_samples, int out_nb_samples)
   }
 
   memcpy(String_val(swr->out_vector), swr->out.data[0], len);
-
-  return ret;
 }
 
-static int convert_to_planar_string(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_planar_string(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples) {
-    int ret = alloc_data(&swr->out, out_nb_samples);
-    if(ret < 0) return ret;
-  }
+  if (out_nb_samples > swr->out.nb_samples)
+    alloc_data(&swr->out, out_nb_samples);
 
   caml_release_runtime_system();
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   size_t len = ret * swr->out.bytes_per_samples;
   int i;
@@ -288,22 +287,20 @@ static int convert_to_planar_string(swr_t *swr, int in_nb_samples, int out_nb_sa
   for(i = 0; i < swr->out.nb_channels; i++) {
     memcpy(String_val(Field(swr->out_vector, i)), swr->out.data[i], len);
   }
-  return ret;
 }
 
-static int convert_to_float_array(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_float_array(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples) {
-    int ret = alloc_data(&swr->out, out_nb_samples);
-    if(ret < 0) return ret;
-  }
+  if (out_nb_samples > swr->out.nb_samples)
+    alloc_data(&swr->out, out_nb_samples);
 
   caml_release_runtime_system();
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   size_t len = ret * swr->out.nb_channels;
   int i;
@@ -319,22 +316,20 @@ static int convert_to_float_array(swr_t *swr, int in_nb_samples, int out_nb_samp
   for (i = 0; i < len; i++) {
     Store_double_field(swr->out_vector, i, pcm[i]);
   }
-  return ret;
 }
 
-static int convert_to_planar_float_array(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_planar_float_array(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples) {
-    int ret = alloc_data(&swr->out, out_nb_samples);
-    if(ret < 0) return ret;
-  }
+  if (out_nb_samples > swr->out.nb_samples)
+    alloc_data(&swr->out, out_nb_samples);
 
   caml_release_runtime_system();
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   int i, j;
   double *pcm;
@@ -353,7 +348,6 @@ static int convert_to_planar_float_array(swr_t *swr, int in_nb_samples, int out_
     for (j = 0; j < ret; j++)
       Store_double_field(Field(swr->out_vector, i), j, pcm[j]);
   }
-  return ret;
 }
 
 static void alloc_out_ba(swr_t *swr, int nb_samples)
@@ -368,7 +362,7 @@ static void alloc_out_ba(swr_t *swr, int nb_samples)
   swr->out.nb_samples = nb_samples;
 }
 
-static int convert_to_ba(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_ba(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
   if (out_nb_samples > swr->out.nb_samples || swr->release_out_vector) {
@@ -379,10 +373,10 @@ static int convert_to_ba(swr_t *swr, int in_nb_samples, int out_nb_samples)
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   Caml_ba_array_val(swr->out_vector)->dim[0] = ret * swr->out.nb_channels;
-  return ret;
 }
 
 
@@ -401,7 +395,7 @@ static void alloc_out_planar_ba(swr_t *swr, int nb_samples)
   swr->out.nb_samples = nb_samples;
 }
 
-static int convert_to_planar_ba(swr_t *swr, int in_nb_samples, int out_nb_samples)
+static inline void convert_to_planar_ba(swr_t *swr, int in_nb_samples, int out_nb_samples)
 {
   // Allocate out data if needed
   if (out_nb_samples > swr->out.nb_samples || swr->release_out_vector) {
@@ -412,13 +406,13 @@ static int convert_to_planar_ba(swr_t *swr, int in_nb_samples, int out_nb_sample
   int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
                         (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
-  if(ret < 0) return ret;
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   int i;
   for(i = 0; i < swr->out.nb_channels; i++) {
     Caml_ba_array_val(Field(swr->out_vector, i))->dim[0] = ret;
   }
-  return ret;
 }
 
 CAMLprim value ocaml_swresample_convert(value _swr, value _in_vector)
@@ -430,7 +424,7 @@ CAMLprim value ocaml_swresample_convert(value _swr, value _in_vector)
   if(swr->in.is_planar) {
     int in_nb_channels = Wosize_val(_in_vector);
 
-    if(in_nb_channels != swr->in.nb_channels) Raise(EXN_FAILURE, "Swresample failed to convert %d channels : %d channels were expected", in_nb_channels, swr->in.nb_channels);
+    if(in_nb_channels != swr->in.nb_channels) Fail( "Swresample failed to convert %d channels : %d channels were expected", in_nb_channels, swr->in.nb_channels);
   }
 
   // Optionnaly release the output vector
@@ -440,14 +434,13 @@ CAMLprim value ocaml_swresample_convert(value _swr, value _in_vector)
 
   // acquisition of the input samples and the input number of samples per channel
   int in_nb_samples = swr->get_in_samples(swr, &_in_vector);
-  if(in_nb_samples < 0) Raise(EXN_FAILURE, "Failed to get input samples : %s", av_err2str(in_nb_samples));
+  if(in_nb_samples < 0) ocaml_avutil_raise_error(in_nb_samples);
 
   // Computation of the output number of samples per channel according to the input ones
   int out_nb_samples = swr_get_out_samples(swr->context, in_nb_samples);
 
   // Resample and convert input data to output data
-  int ret = swr->convert(swr, in_nb_samples, out_nb_samples);
-  if(ret < 0) Raise(EXN_FAILURE, "Failed to convert samples : %s", av_err2str(ret));
+  swr->convert(swr, in_nb_samples, out_nb_samples);
 
   CAMLreturn(swr->out_vector);
 }
@@ -460,7 +453,9 @@ void swresample_free(swr_t *swr)
   if(swr->in.data && swr->get_in_samples != get_in_samples_frame) {
 
     if(swr->in.owns_data) {
+      caml_release_runtime_system();
       av_freep(&swr->in.data[0]);
+      caml_acquire_runtime_system();
     }
     free(swr->in.data);
   }
@@ -468,7 +463,9 @@ void swresample_free(swr_t *swr)
   if(swr->out.data && swr->convert != convert_to_frame) {
 
     if(swr->out.owns_data) {
+      caml_release_runtime_system();
       av_freep(&swr->out.data[0]);
+      caml_acquire_runtime_system();
     }
     free(swr->out.data);
   }
@@ -496,11 +493,11 @@ static struct custom_operations swr_ops =
 #define NB_OPTIONS_TYPES 3
 
 
-static SwrContext * swresample_set_context(swr_t * swr,
+static inline SwrContext * swresample_set_context(swr_t * swr,
                                            int64_t in_channel_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate,
                                            int64_t out_channel_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, value options[])
 {
-  if( ! swr->context && ! (swr->context = swr_alloc())) Fail("Failed to allocate swresample context");
+  if( ! swr->context && ! (swr->context = swr_alloc())) caml_raise_out_of_memory();
 
   SwrContext *ctx = swr->context;
 
@@ -559,31 +556,34 @@ static SwrContext * swresample_set_context(swr_t * swr,
       }
     }
 
-    if(ret != 0) Fail("Failed to set option : %s", av_err2str(ret));
+    if(ret != 0) ocaml_avutil_raise_error(ret);
   }
 
   // initialize the resampling context
+  caml_release_runtime_system();
   ret = swr_init(ctx);
-  if(ret < 0) Fail("Failed to initialize the resampling context : %s", av_err2str(ret));
+  caml_acquire_runtime_system();
+
+  if(ret < 0) ocaml_avutil_raise_error(ret);
 
   return ctx;
 }
 
 swr_t * swresample_create(vector_kind in_vector_kind, int64_t in_channel_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, vector_kind out_vector_kind, int64_t out_channel_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, value options[])
 {
-  caml_release_runtime_system();
   swr_t * swr = (swr_t*)calloc(1, sizeof(swr_t));
-  if( ! swr) Fail("Failed to allocate Swresample context");
+  if( ! swr) {
+    caml_raise_out_of_memory();
+  }
   
   SwrContext *ctx = swresample_set_context(swr,
                                            in_channel_layout, in_sample_fmt, in_sample_rate,
                                            out_channel_layout, out_sample_fmt, out_sample_rate,
                                            options);
-  caml_acquire_runtime_system();
 
   if( ! ctx) {
     swresample_free(swr);
-    return NULL;
+    caml_raise_out_of_memory();
   }
 
   if(in_vector_kind != Frm) {
@@ -606,6 +606,7 @@ swr_t * swresample_create(vector_kind in_vector_kind, int64_t in_channel_layout,
   caml_register_generational_global_root(&swr->out_vector);
 
   swr->out.bytes_per_samples = av_get_bytes_per_sample(out_sample_fmt);
+
   swr->release_out_vector = 1;
 
   switch(in_vector_kind) {
@@ -681,7 +682,6 @@ CAMLprim value ocaml_swresample_create(value _in_vector_kind, value _in_channel_
   swr_t * swr = swresample_create(in_vector_kind, in_channel_layout, in_sample_fmt, in_sample_rate,
                                   out_vector_kind, out_channel_layout, out_sample_fmt, out_sample_rate,
                                   options);
-  if( ! swr) Raise(EXN_FAILURE, "%s", ocaml_av_error_msg);
 
   ans = caml_alloc_custom(&swr_ops, sizeof(swr_t*), 0, 1);
   Swr_val(ans) = swr;

--- a/src/swscale.mli
+++ b/src/swscale.mli
@@ -60,7 +60,7 @@ module Make (I : VideoData) (O : VideoData) : sig
 
   val convert : t -> I.t -> O.t
   (** [Swscale.convert ctx ivd] scale and convert the [ivd] input video data to the output video data according to the [ctx] scaler context format.
-@raise Failure if the conversion failed. *)
+@raise Error if the conversion failed. *)
 end
 
 

--- a/src/swscale_stubs.c
+++ b/src/swscale_stubs.c
@@ -282,7 +282,7 @@ static int alloc_out_frame(sws_t *sws)
     sws->out.slice = frame->data;
     sws->out.stride = frame->linesize;
 
-    value_of_frame(frame, &v);
+    v = value_of_frame(frame);
     caml_modify_generational_global_root(&sws->out_vector, v);
   } while(0);
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,6 @@ INCDIRS = ../src
 THREADS = yes
 TRASH = *.raw *.flac *.ogg *.mp4 *.mkv
 
-all: dc
 
 test: all
 	./test ../examples/decode_audio/A4.ogg ../examples/transcode_aac/A4.mp4 ../examples/encoding/out.mkv


### PR DESCRIPTION
Okay, admittedly this got a little out of hands but eventually I believe that these are great changes. Here's the rundown:
- Use library-specific errors, wrap previous `Failure` exception into one of these
- Since logs can potentially be `OCaml` callbacks, we have to make sure that each call to a library function release the global lock. This includes freeing function. A couple do not (checked the source) but also I could have missed some.
- Thus, cleanup the general logic and raise as soon as possible.
- Finally, fix decoding logic, same as in #29 