### PR TITLE
Cleanup encoder

### DIFF
--- a/av/av.ml
+++ b/av/av.ml
@@ -262,9 +262,6 @@ external seek :
   (input, _) stream -> Time_format.t -> Int64.t -> seek_flag array -> unit
   = "ocaml_av_seek_frame"
 
-external reuse_output : input container -> bool -> unit
-  = "ocaml_av_reuse_output"
-
 (* Output *)
 external open_output :
   ?format:(output, _) format ->

--- a/av/av.ml
+++ b/av/av.ml
@@ -142,6 +142,9 @@ external get_time_base : (_, _) stream -> Avutil.rational
 external set_time_base : (_, _) stream -> Avutil.rational -> unit
   = "ocaml_av_set_stream_time_base"
 
+external get_frame_size : (output, audio) stream -> int
+  = "ocaml_av_get_stream_frame_size"
+
 external get_pixel_aspect : (_, video) stream -> Avutil.rational
   = "ocaml_av_get_stream_pixel_aspect"
 

--- a/av/av.mli
+++ b/av/av.mli
@@ -254,7 +254,7 @@ val get_output : (output, _) stream -> output container
 
     At least one of [channels] or [channel_layout] must be passed.
 
-    Frames passed to this stream for encoding must have a PTS set accoring to
+    Frames passed to this stream for encoding must have a PTS set according to
     the given [time_base]. [1/sample_rate] is usually a good value for the
     [time_base].
 
@@ -282,7 +282,7 @@ val new_audio_stream :
     settable on the stream's internal AVCodec. After returning, if [opts] was
     passed, unused options are left in the hash table.
 
-    Frames passed to this stream for encoding must have a PTS set accoring to
+    Frames passed to this stream for encoding must have a PTS set according to
     the given [time_base]. [1/frame_rate] is usually a good value for the
     [time_base].
 
@@ -316,8 +316,8 @@ val write_packet : (output, 'media) stream -> 'media Avcodec.Packet.t -> unit
 
 (** [Av.write_frame os frm] write the [frm] frame to the [os] output stream.
 
-    Frame PTS, if set, are using the stream's [time_base], which can be grabbed
-    via [get_time_base].
+    Frame PTS should be set and counted in units of [time_base], as passed
+    when creating the stream
 
     Raise Error if the writing failed. *)
 val write_frame : (output, 'media) stream -> 'media frame -> unit

--- a/av/av.mli
+++ b/av/av.mli
@@ -114,6 +114,9 @@ val get_time_base : (_, _) stream -> Avutil.rational
     [time_base]. *)
 val set_time_base : (_, _) stream -> Avutil.rational -> unit
 
+(** [Av.get_frame_size stream] return the frame size for the given audio stream. *)
+val get_frame_size : (output, audio) stream -> int
+
 (** [Av.get_pixel_aspect stream] return the pixel aspect of the [stream]. *)
 val get_pixel_aspect : (_, video) stream -> Avutil.rational
 
@@ -313,6 +316,10 @@ val new_subtitle_stream :
 val write_packet : (output, 'media) stream -> 'media Avcodec.Packet.t -> unit
 
 (** [Av.write_frame os frm] write the [frm] frame to the [os] output stream.
+
+    Frame PTS, if set, are using the stream's [time_base], which can be grabbed
+    via [get_time_base].
+
     Raise Error if the writing failed. *)
 val write_frame : (output, 'media) stream -> 'media frame -> unit
 

--- a/av/av.mli
+++ b/av/av.mli
@@ -207,15 +207,6 @@ type seek_flag =
 val seek :
   (input, _) stream -> Time_format.t -> Int64.t -> seek_flag array -> unit
 
-(** [Av.reuse_output ro] enables or disables the reuse of {!Av.read_packet},
-    {!Av.iter_packet}, {!Av.read_frame}, {!Av.iter_frame},
-    {!Av.read_input_packet}, {!Av.iter_input_packet}, {!Av.read_input_frame} and
-    {!Av.iter_input_frame} output according to the value of [ro]. Reusing the
-    output reduces the number of memory allocations. In this cas, the data
-    returned by a reading function is invalidated by a new call to this
-    function. *)
-val reuse_output : input container -> bool -> unit
-
 (** {5 Output} *)
 
 (** [Av.open_output ?format ?opts filename] open the output file named

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -62,7 +62,6 @@ typedef struct av_t {
 
   // output
   int header_written;
-  int release_out;
   int custom_io;
 } av_t;
 
@@ -522,7 +521,6 @@ static av_t *open_input(char *url, AVInputFormat *format,
   }
 
   av->is_input = 1;
-  av->release_out = 1;
   av->frames_pending = 0;
   av->format_context = format_context;
   av->streams = NULL;
@@ -726,12 +724,6 @@ CAMLprim value ocaml_av_get_duration(value _av, value _stream_index,
   ans = caml_copy_int64((duration * second_fractions * num) / den);
 
   CAMLreturn(ans);
-}
-
-CAMLprim value ocaml_av_reuse_output(value _av, value _reuse_output) {
-  CAMLparam2(_av, _reuse_output);
-  Av_val(_av)->release_out = !Bool_val(_reuse_output);
-  CAMLreturn(Val_unit);
 }
 
 static stream_t **allocate_input_context(av_t *av) {

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -9,6 +9,10 @@
 #include <caml/mlvalues.h>
 #include <caml/threads.h>
 
+#ifndef Bytes_val
+#define Bytes_val String_val
+#endif
+
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/audio_fifo.h>
@@ -296,7 +300,7 @@ static int ocaml_avio_write_callback(void *private, uint8_t *buf,
 
   caml_register_generational_global_root(&buffer);
 
-  memcpy(String_val(buffer), buf, buf_size);
+  memcpy(Bytes_val(buffer), buf, buf_size);
 
   res =
       caml_callback3_exn(avio->write_cb, buffer, Val_int(0), Val_int(buf_size));
@@ -564,8 +568,8 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _opts) {
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -623,8 +627,8 @@ CAMLprim value ocaml_av_open_input_stream(value _avio, value _format,
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1394,8 +1398,8 @@ CAMLprim value ocaml_av_open_output(value _format, value _filename,
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1444,8 +1448,8 @@ CAMLprim value ocaml_av_open_output_format(value _format, value _opts) {
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1496,8 +1500,8 @@ CAMLprim value ocaml_av_open_output_stream(value _format, value _avio,
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1661,8 +1665,8 @@ CAMLprim value ocaml_av_new_audio_stream(value _av, value _sample_fmt,
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1718,8 +1722,8 @@ CAMLprim value ocaml_av_new_video_stream(value _av, value _codec, value _opts) {
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);
@@ -1782,8 +1786,8 @@ CAMLprim value ocaml_av_new_subtitle_stream(value _av, value _codec,
 
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
-    key = String_val(Field(Field(_opts, i), 0));
-    val = String_val(Field(Field(_opts, i), 1));
+    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
+    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
     err = av_dict_set(&options, key, val, 0);
     if (err < 0) {
       av_dict_free(&options);

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -15,8 +15,6 @@
 #include <libavutil/avstring.h>
 #include <libavutil/opt.h>
 #include <libavutil/timestamp.h>
-#include <libswresample/swresample.h>
-#include <libswscale/swscale.h>
 
 #include "av_stubs.h"
 #include "avcodec_stubs.h"
@@ -42,14 +40,6 @@ typedef struct {
 
   // input
   int got_frame;
-
-  // output
-  struct SwsContext *sws_ctx;
-  struct SwrContext *swr_ctx;
-  AVFrame *sw_frame;
-  AVAudioFifo *audio_fifo;
-  AVFrame *enc_frame;
-  int64_t pts;
 } stream_t;
 
 typedef struct av_t {
@@ -93,26 +83,6 @@ static void free_stream(stream_t *stream) {
 
   if (stream->codec_context)
     avcodec_free_context(&stream->codec_context);
-
-  if (stream->swr_ctx) {
-    swr_free(&stream->swr_ctx);
-  }
-
-  if (stream->sws_ctx) {
-    sws_freeContext(stream->sws_ctx);
-  }
-
-  if (stream->sw_frame) {
-    av_frame_free(&stream->sw_frame);
-  }
-
-  if (stream->audio_fifo) {
-    av_audio_fifo_free(stream->audio_fifo);
-  }
-
-  if (stream->enc_frame) {
-    av_frame_free(&stream->enc_frame);
-  }
 
   free(stream);
 }
@@ -225,6 +195,14 @@ CAMLprim value ocaml_av_set_stream_time_base(value _stream, value _time_base) {
   av->format_context->streams[index]->time_base = rational_of_value(_time_base);
 
   CAMLreturn(Val_unit);
+}
+
+CAMLprim value ocaml_av_get_stream_frame_size(value _stream) {
+  CAMLparam1(_stream);
+  av_t *av = StreamAv_val(_stream);
+  int index = StreamIndex_val(_stream);
+
+  CAMLreturn(Val_int(av->streams[index]->codec_context->frame_size));
 }
 
 CAMLprim value ocaml_av_get_stream_pixel_aspect(value _stream) {
@@ -1667,45 +1645,6 @@ static stream_t *new_audio_stream(av_t *av, enum AVSampleFormat sample_fmt,
 
   init_stream_encoder(av, stream, options);
 
-  if (enc_ctx->frame_size > 0 ||
-      !(enc_ctx->codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE)) {
-    caml_release_runtime_system();
-
-    // Allocate the buffer frame and audio fifo if the codec doesn't support
-    // variable frame size
-    stream->enc_frame = av_frame_alloc();
-    if (!stream->enc_frame) {
-      av_dict_free(options);
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
-
-    stream->enc_frame->nb_samples = enc_ctx->frame_size;
-    stream->enc_frame->channel_layout = enc_ctx->channel_layout;
-    stream->enc_frame->format = enc_ctx->sample_fmt;
-    stream->enc_frame->sample_rate = enc_ctx->sample_rate;
-
-    int ret = av_frame_get_buffer(stream->enc_frame, 0);
-
-    if (ret < 0) {
-      av_dict_free(options);
-      caml_acquire_runtime_system();
-      ocaml_avutil_raise_error(ret);
-    }
-
-    // Create the FIFO buffer based on the specified output sample format.
-    stream->audio_fifo =
-        av_audio_fifo_alloc(enc_ctx->sample_fmt, enc_ctx->channels, 1);
-
-    if (!stream->audio_fifo) {
-      av_dict_free(options);
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
-
-    caml_acquire_runtime_system();
-  }
-
   return stream;
 }
 
@@ -1982,91 +1921,8 @@ static void write_frame(av_t *av, int stream_index, AVCodecContext *enc_ctx,
     ocaml_avutil_raise_error(ret);
 }
 
-static AVFrame *resample_audio_frame(stream_t *stream, AVFrame *frame) {
-  AVCodecContext *enc_ctx = stream->codec_context;
-
-  caml_release_runtime_system();
-
-  if (!stream->swr_ctx) {
-    // create resampler context
-    struct SwrContext *swr_ctx = swr_alloc();
-
-    if (!swr_ctx) {
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
-    stream->swr_ctx = swr_ctx;
-
-    // set options
-    av_opt_set_channel_layout(swr_ctx, "in_channel_layout",
-                              frame->channel_layout, 0);
-    av_opt_set_int(swr_ctx, "in_sample_rate", frame->sample_rate, 0);
-    av_opt_set_sample_fmt(swr_ctx, "in_sample_fmt",
-                          (enum AVSampleFormat)frame->format, 0);
-    av_opt_set_channel_layout(swr_ctx, "out_channel_layout",
-                              enc_ctx->channel_layout, 0);
-    av_opt_set_int(swr_ctx, "out_sample_rate", enc_ctx->sample_rate, 0);
-    av_opt_set_sample_fmt(swr_ctx, "out_sample_fmt", enc_ctx->sample_fmt, 0);
-
-    // initialize the resampling context
-    int ret = swr_init(swr_ctx);
-
-    if (ret < 0) {
-      caml_acquire_runtime_system();
-      ocaml_avutil_raise_error(ret);
-    }
-  }
-
-  int out_nb_samples = swr_get_out_samples(stream->swr_ctx, frame->nb_samples);
-
-  if (!stream->sw_frame || out_nb_samples > stream->sw_frame->nb_samples) {
-    if (stream->sw_frame) {
-      av_frame_free(&stream->sw_frame);
-    }
-
-    // Allocate the resampler frame
-    stream->sw_frame = av_frame_alloc();
-
-    if (!stream->sw_frame) {
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
-
-    stream->sw_frame->nb_samples = out_nb_samples;
-    stream->sw_frame->channel_layout = enc_ctx->channel_layout;
-    stream->sw_frame->format = enc_ctx->sample_fmt;
-    stream->sw_frame->sample_rate = enc_ctx->sample_rate;
-
-    int ret = av_frame_get_buffer(stream->sw_frame, 0);
-
-    if (ret < 0) {
-      caml_acquire_runtime_system();
-      ocaml_avutil_raise_error(ret);
-    }
-  }
-
-  int ret = av_frame_make_writable(stream->sw_frame);
-
-  if (ret < 0) {
-    caml_acquire_runtime_system();
-    ocaml_avutil_raise_error(ret);
-  }
-
-  // convert to destination format
-  ret = swr_convert(stream->swr_ctx, stream->sw_frame->extended_data,
-                    out_nb_samples, (const uint8_t **)frame->extended_data,
-                    frame->nb_samples);
-
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  return stream->sw_frame;
-}
-
 static void write_audio_frame(av_t *av, int stream_index, AVFrame *frame) {
-  int err, fifo_size, frame_size;
+  int err, frame_size;
 
   if (av->format_context->nb_streams < stream_index)
     Fail("Stream index not found!");
@@ -2078,119 +1934,7 @@ static void write_audio_frame(av_t *av, int stream_index, AVFrame *frame) {
 
   AVCodecContext *enc_ctx = stream->codec_context;
 
-  if (frame && (frame->sample_rate != enc_ctx->sample_rate ||
-                frame->channel_layout != enc_ctx->channel_layout ||
-                ((enum AVSampleFormat)frame->format) != enc_ctx->sample_fmt)) {
-
-    frame = resample_audio_frame(stream, frame);
-  }
-
-  if (stream->audio_fifo == NULL) {
-
-    if (frame) {
-      frame->pts = stream->pts;
-      stream->pts += frame->nb_samples;
-    }
-
-    write_frame(av, stream_index, enc_ctx, frame);
-  } else {
-    AVAudioFifo *fifo = stream->audio_fifo;
-    AVFrame *output_frame = stream->enc_frame;
-
-    caml_release_runtime_system();
-
-    if (frame != NULL) {
-      // Store the new samples in the FIFO buffer.
-      err = av_audio_fifo_write(fifo,
-                                (void **)(const uint8_t **)frame->extended_data,
-                                frame->nb_samples);
-
-      if (err < 0) {
-        caml_acquire_runtime_system();
-        ocaml_avutil_raise_error(err);
-      }
-    }
-
-    fifo_size = av_audio_fifo_size(fifo);
-    frame_size = enc_ctx->frame_size;
-
-    for (; fifo_size >= frame_size || frame == NULL;
-         fifo_size = av_audio_fifo_size(fifo)) {
-      if (fifo_size > 0) {
-        err = av_frame_make_writable(output_frame);
-        if (err < 0) {
-          caml_acquire_runtime_system();
-          ocaml_avutil_raise_error(err);
-        }
-
-        int read_size =
-            av_audio_fifo_read(fifo, (void **)output_frame->data, frame_size);
-
-        if (frame && read_size < frame_size) {
-          caml_acquire_runtime_system();
-          Fail("Invalid input: read_size < frame_size");
-        }
-
-        output_frame->nb_samples = frame_size;
-        output_frame->pts = stream->pts;
-        stream->pts += frame_size;
-      } else {
-        output_frame = NULL;
-      }
-
-      caml_acquire_runtime_system();
-      write_frame(av, stream_index, enc_ctx, output_frame);
-      caml_release_runtime_system();
-
-      if (fifo_size == 0)
-        break;
-    }
-  }
-
-  caml_acquire_runtime_system();
-}
-
-static void scale_video_frame(stream_t *stream, AVFrame *frame) {
-  AVCodecContext *enc_ctx = stream->codec_context;
-
-  if (!stream->sws_ctx) {
-    // create scale context
-    stream->sws_ctx = sws_getContext(
-        frame->width, frame->height, (enum AVPixelFormat)frame->format,
-        enc_ctx->width, enc_ctx->height, (enum AVPixelFormat)frame->format,
-        SWS_BICUBIC, NULL, NULL, NULL);
-    if (!stream->sws_ctx)
-      caml_raise_out_of_memory();
-
-    // Allocate the scale frame
-    stream->sw_frame = av_frame_alloc();
-    if (!stream->sw_frame)
-      caml_raise_out_of_memory();
-
-    stream->sw_frame->width = enc_ctx->width;
-    stream->sw_frame->height = enc_ctx->height;
-    stream->sw_frame->format = enc_ctx->pix_fmt;
-
-    caml_release_runtime_system();
-    int ret = av_frame_get_buffer(stream->sw_frame, 32);
-    caml_acquire_runtime_system();
-    if (ret < 0)
-      ocaml_avutil_raise_error(ret);
-  }
-
-  caml_release_runtime_system();
-  int ret = av_frame_make_writable(stream->sw_frame);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  // convert to destination format
-  caml_release_runtime_system();
-  sws_scale(stream->sws_ctx, (const uint8_t *const *)frame->data,
-            frame->linesize, 0, frame->height, stream->sw_frame->data,
-            stream->sw_frame->linesize);
-  caml_acquire_runtime_system();
+  write_frame(av, stream_index, enc_ctx, frame);
 }
 
 static void write_video_frame(av_t *av, int stream_index, AVFrame *frame) {
@@ -2206,14 +1950,6 @@ static void write_video_frame(av_t *av, int stream_index, AVFrame *frame) {
     Fail("Failed to write video frame with no encoder");
 
   AVCodecContext *enc_ctx = stream->codec_context;
-
-  if (frame &&
-      (frame->width != enc_ctx->width || frame->height != enc_ctx->height))
-    scale_video_frame(stream, frame);
-
-  if (frame) {
-    frame->pts = stream->pts++;
-  }
 
   write_frame(av, stream_index, enc_ctx, frame);
 }

--- a/av/config/discover.ml
+++ b/av/config/discover.ml
@@ -1,6 +1,6 @@
 module C = Configurator.V1
 
-let packages = [("avutil", "56.14.100"); ("avformat", "58.12.100")]
+let packages = [("avutil", "55.78.100"); ("avformat", "58.12.100")]
 
 let () =
   C.main ~name:"ffmpeg-av-pkg-config" (fun c ->

--- a/av/config/discover.ml
+++ b/av/config/discover.ml
@@ -1,6 +1,6 @@
 module C = Configurator.V1
 
-let packages = [("avutil", "55.78.100"); ("avformat", "58.12.100")]
+let packages = [("avutil", "55.78.100"); ("avformat", "57.83.100")]
 
 let () =
   C.main ~name:"ffmpeg-av-pkg-config" (fun c ->

--- a/av/config/discover.ml
+++ b/av/config/discover.ml
@@ -1,12 +1,6 @@
 module C = Configurator.V1
 
-let packages =
-  [
-    ("avutil", "56.14.100");
-    ("avformat", "58.12.100");
-    ("swscale", "5.1.100");
-    ("swresample", "3.1.100");
-  ]
+let packages = [("avutil", "56.14.100"); ("avformat", "58.12.100")]
 
 let () =
   C.main ~name:"ffmpeg-av-pkg-config" (fun c ->

--- a/avcodec/avcodec.mli
+++ b/avcodec/avcodec.mli
@@ -7,6 +7,9 @@ type 'a params
 type 'media decoder
 type 'media encoder
 
+(** Codec capabilities. *)
+type capability = Codec_capabilities.t
+
 (** Packet. *)
 module Packet : sig
   (** Packet type *)
@@ -79,6 +82,9 @@ module Audio : sig
       sample rate. *)
   val find_best_sample_rate : _ t -> int -> int
 
+  (** Get the encoding capabilities for this codec. *)
+  val capabilities : [ `Encoder ] t -> capability list
+
   (** [Avcodec.Audio.create_parser codec] create an audio packet parser.
 
       Raise Error if the parser creation failed. *)
@@ -89,11 +95,21 @@ module Audio : sig
       Raise Error if the decoder creation failed. *)
   val create_decoder : [ `Decoder ] t -> audio decoder
 
-  (** [Avcodec.Audio.create_encoder ~bit_rate:bit_rate codec] create an audio
+  (** [Avcodec.Audio.create_encoder ~bitrate:bitrate codec] create an audio
       encoder.
 
       Raise Error if the encoder creation failed. *)
-  val create_encoder : ?bit_rate:int -> [ `Encoder ] t -> audio encoder
+  val create_encoder :
+    ?bit_rate:int ->
+    channel_layout:Avutil.Channel_layout.t ->
+    channels:int ->
+    sample_format:Avutil.Sample_format.t ->
+    sample_rate:int ->
+    [ `Encoder ] t ->
+    audio encoder
+
+  (** Get the desired frame_size for this encoder. *)
+  val frame_size : audio encoder -> int
 
   (** Audio codec ids. Careful: different codecs share the same ID, e.g. aac and
       libfdk_aac *)
@@ -156,6 +172,9 @@ module Video : sig
   val find_best_pixel_format :
     _ t -> Avutil.Pixel_format.t -> Avutil.Pixel_format.t
 
+  (** Get the encoding capabilities for this codec. *)
+  val capabilities : [ `Encoder ] t -> capability list
+
   (** [Avcodec.Video.create_parser codec] create an video packet parser.
 
       Raise Error if the parser creation failed. *)
@@ -171,7 +190,13 @@ module Video : sig
 
       Raise Error if the encoder creation failed. *)
   val create_encoder :
-    ?bit_rate:int -> ?frame_rate:int -> [ `Encoder ] t -> video encoder
+    ?bit_rate:int ->
+    width:int ->
+    height:int ->
+    pixel_format:Avutil.Pixel_format.t ->
+    framerate:Avutil.rational ->
+    [ `Encoder ] t ->
+    video encoder
 
   (** Video codec ids. Careful: different codecs share the same ID, e.g. aac and
       libfdk_aac *)

--- a/avcodec/avcodec_stubs.c
+++ b/avcodec/avcodec_stubs.c
@@ -8,7 +8,6 @@
 #include <caml/threads.h>
 
 #include "avutil_stubs.h"
-#include <libavformat/avformat.h>
 
 #include "avcodec_stubs.h"
 #include "codec_capabilities_stubs.h"

--- a/avcodec/avcodec_stubs.c
+++ b/avcodec/avcodec_stubs.c
@@ -9,9 +9,9 @@
 
 #include "avutil_stubs.h"
 #include <libavformat/avformat.h>
-#include <libavutil/audio_fifo.h>
 
 #include "avcodec_stubs.h"
+#include "codec_capabilities_stubs.h"
 #include "codec_id_stubs.h"
 
 value ocaml_avcodec_init(value unit) {
@@ -55,13 +55,11 @@ CAMLprim value ocaml_avcodec_subtitle_codec_id_to_AVCodecID(value _codec_id) {
 /***** AVCodecContext *****/
 
 static AVCodecContext *create_AVCodecContext(AVCodec *codec) {
-  AVCodecContext *codec_context = NULL;
+  AVCodecContext *codec_context;
 
-  if (codec) {
-    caml_release_runtime_system();
-    codec_context = avcodec_alloc_context3(codec);
-    caml_acquire_runtime_system();
-  }
+  caml_release_runtime_system();
+  codec_context = avcodec_alloc_context3(codec);
+  caml_acquire_runtime_system();
 
   if (!codec_context)
     caml_raise_out_of_memory();
@@ -216,11 +214,6 @@ static parser_t *create_parser(AVCodec *codec) {
 
   parser->codec_context = create_AVCodecContext(codec);
 
-  if (!parser->codec_context) {
-    free_parser(parser);
-    caml_raise_out_of_memory();
-  }
-
   return parser;
 }
 
@@ -299,91 +292,57 @@ typedef struct {
   AVCodec *codec;
   AVCodecContext *codec_context;
   // output
-  int bit_rate;
-  int frame_rate;
-  AVAudioFifo *audio_fifo;
-  AVFrame *enc_frame;
-  int64_t pts;
   int flushed;
 } codec_context_t;
 
 #define CodecContext_val(v) (*(codec_context_t **)Data_custom_val(v))
 
-static void free_codec_context(codec_context_t *ctx) {
-  if (!ctx)
-    return;
-
-  caml_release_runtime_system();
+static void codec_context(value v) {
+  codec_context_t *ctx = CodecContext_val(v);
   if (ctx->codec_context)
     avcodec_free_context(&ctx->codec_context);
 
-  if (ctx->audio_fifo) {
-    av_audio_fifo_free(ctx->audio_fifo);
-  }
-
-  if (ctx->enc_frame) {
-    av_frame_free(&ctx->enc_frame);
-  }
-  caml_acquire_runtime_system();
-
   free(ctx);
 }
-
-static void codec_context(value v) { free_codec_context(CodecContext_val(v)); }
 
 static struct custom_operations codec_context_ops = {
     "ocaml_codec_context",    codec_context,
     custom_compare_default,   custom_hash_default,
     custom_serialize_default, custom_deserialize_default};
 
-static codec_context_t *create_codec_context(AVCodec *codec, int decoder) {
+CAMLprim value ocaml_avcodec_create_decoder(value _codec) {
+  CAMLparam0();
+  CAMLlocal1(ans);
+  AVCodec *codec = (AVCodec *)_codec;
+
   codec_context_t *ctx = (codec_context_t *)calloc(1, sizeof(codec_context_t));
   if (!ctx)
     caml_raise_out_of_memory();
 
-  if (decoder) {
-    ctx->codec = codec;
-    ctx->codec_context = create_AVCodecContext(ctx->codec);
-
-    if (!ctx->codec_context) {
-      free_codec_context(ctx);
-      caml_raise_out_of_memory();
-    }
-  } else {
-    ctx->codec = codec;
-    // in case of encoding, the AVCodecContext will be created with the
-    // properties of the first sended frame
-  }
-
-  return ctx;
-}
-
-CAMLprim value ocaml_avcodec_create_context(value _codec, value _decoder,
-                                            value _bit_rate,
-                                            value _frame_rate) {
-  CAMLparam2(_bit_rate, _frame_rate);
-  CAMLlocal1(ans);
-  AVCodec *codec = (AVCodec *)_codec;
-
-  codec_context_t *ctx = create_codec_context(codec, Int_val(_decoder));
-
   ans = caml_alloc_custom(&codec_context_ops, sizeof(codec_context_t *), 0, 1);
   CodecContext_val(ans) = ctx;
 
-  ctx->bit_rate = Is_block(_bit_rate) ? Int_val(Field(_bit_rate, 0)) : 0;
-  ctx->frame_rate = Is_block(_frame_rate) ? Int_val(Field(_frame_rate, 0)) : 0;
+  ctx->codec = codec;
+  ctx->codec_context = create_AVCodecContext(ctx->codec);
 
   CAMLreturn(ans);
 }
 
-static void open_codec(codec_context_t *ctx, AVFrame *frame) {
-  if (!frame)
-    Fail("Failed to open encoder without frame");
+CAMLprim value ocaml_avcodec_create_audio_encoder_native(
+    value _bit_rate, value _channel_layout, value _channels, value _sample_fmt,
+    value _sample_rate, value _codec) {
+  CAMLparam1(_bit_rate);
+  CAMLlocal1(ans);
+  AVCodec *codec = (AVCodec *)_codec;
 
-  AVCodec *codec = ctx->codec;
+  codec_context_t *ctx = (codec_context_t *)calloc(1, sizeof(codec_context_t));
+  if (!ctx)
+    caml_raise_out_of_memory();
 
-  if (codec->type != AVMEDIA_TYPE_AUDIO && codec->type != AVMEDIA_TYPE_VIDEO)
-    Fail("Failed to open unsupported encoder type");
+  ans = caml_alloc_custom(&codec_context_ops, sizeof(codec_context_t *), 0, 1);
+  CodecContext_val(ans) = ctx;
+
+  ctx->codec = codec;
 
   caml_release_runtime_system();
   ctx->codec_context = avcodec_alloc_context3(codec);
@@ -393,64 +352,84 @@ static void open_codec(codec_context_t *ctx, AVFrame *frame) {
     caml_raise_out_of_memory();
   }
 
-  if (codec->type == AVMEDIA_TYPE_AUDIO) {
-    ctx->codec_context->channel_layout = frame->channel_layout;
-    ctx->codec_context->channels = frame->channels;
-    ctx->codec_context->sample_fmt = (enum AVSampleFormat)frame->format;
-    ctx->codec_context->sample_rate = frame->sample_rate;
-    ctx->codec_context->time_base = (AVRational){1, frame->sample_rate};
-  } else {
-    ctx->codec_context->width = frame->width;
-    ctx->codec_context->height = frame->height;
-    ctx->codec_context->pix_fmt = (enum AVPixelFormat)frame->format;
-    ctx->codec_context->framerate = (AVRational){ctx->frame_rate, 1};
-    ctx->codec_context->time_base = (AVRational){1, ctx->frame_rate};
-  }
-
-  ctx->codec_context->bit_rate = ctx->bit_rate;
+  ctx->codec_context->channel_layout = ChannelLayout_val(_channel_layout);
+  ctx->codec_context->channels = Int_val(_channels);
+  ctx->codec_context->sample_fmt = SampleFormat_val(_sample_fmt);
+  ctx->codec_context->sample_rate = Int_val(_sample_rate);
+  ctx->codec_context->time_base = (AVRational){1, Int_val(_sample_rate)};
+  ctx->codec_context->bit_rate =
+      Is_block(_bit_rate) ? Int_val(Field(_bit_rate, 0)) : 0;
 
   // Open the codec
-  int ret = avcodec_open2(ctx->codec_context, NULL, NULL);
+  int ret = avcodec_open2(ctx->codec_context, ctx->codec, NULL);
+  caml_acquire_runtime_system();
 
-  if (ret < 0) {
-    caml_acquire_runtime_system();
+  if (ret < 0)
     ocaml_avutil_raise_error(ret);
+
+  CAMLreturn(ans);
+}
+
+CAMLprim value ocaml_avcodec_create_audio_encoder_bytecode(value *argv,
+                                                           int argn) {
+  return ocaml_avcodec_create_audio_encoder_native(argv[0], argv[1], argv[2],
+                                                   argv[3], argv[4], argv[5]);
+}
+
+CAMLprim value ocaml_avcodec_create_video_encoder_native(
+    value _bit_rate, value _width, value _height, value _pixel_fmt,
+    value _framerate_num, value _framerate_den, value _codec) {
+  CAMLparam1(_bit_rate);
+  CAMLlocal1(ans);
+  AVCodec *codec = (AVCodec *)_codec;
+
+  codec_context_t *ctx = (codec_context_t *)calloc(1, sizeof(codec_context_t));
+  if (!ctx)
+    caml_raise_out_of_memory();
+
+  ans = caml_alloc_custom(&codec_context_ops, sizeof(codec_context_t *), 0, 1);
+  CodecContext_val(ans) = ctx;
+
+  ctx->codec = codec;
+  caml_release_runtime_system();
+  ctx->codec_context = avcodec_alloc_context3(codec);
+  caml_acquire_runtime_system();
+
+  if (!ctx->codec_context) {
+    caml_acquire_runtime_system();
+    caml_raise_out_of_memory();
   }
 
-  if (ctx->codec_context->frame_size > 0 ||
-      !(ctx->codec_context->codec->capabilities &
-        AV_CODEC_CAP_VARIABLE_FRAME_SIZE)) {
+  ctx->codec_context->width = Int_val(_width);
+  ctx->codec_context->height = Int_val(_height);
+  ctx->codec_context->pix_fmt = PixelFormat_val(_pixel_fmt);
+  ctx->codec_context->framerate =
+      (AVRational){Int_val(_framerate_num), Int_val(_framerate_den)};
+  ctx->codec_context->time_base =
+      (AVRational){Int_val(_framerate_den), Int_val(_framerate_num)};
+  ctx->codec_context->bit_rate =
+      Is_block(_bit_rate) ? Int_val(Field(_bit_rate, 0)) : 0;
 
-    // Allocate the buffer frame and audio fifo if the codec doesn't support
-    // variable frame size
-    ctx->enc_frame = av_frame_alloc();
+  // Open the codec
+  int ret = avcodec_open2(ctx->codec_context, ctx->codec, NULL);
+  caml_acquire_runtime_system();
 
-    if (!ctx->enc_frame) {
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
+  if (ret < 0)
+    ocaml_avutil_raise_error(ret);
 
-    ctx->enc_frame->nb_samples = ctx->codec_context->frame_size;
-    ctx->enc_frame->channel_layout = ctx->codec_context->channel_layout;
-    ctx->enc_frame->format = ctx->codec_context->sample_fmt;
-    ctx->enc_frame->sample_rate = ctx->codec_context->sample_rate;
+  CAMLreturn(ans);
+}
 
-    int ret = av_frame_get_buffer(ctx->enc_frame, 0);
+CAMLprim value ocaml_avcodec_create_video_encoder_bytecode(value *argv,
+                                                           int argn) {
+  return ocaml_avcodec_create_video_encoder_native(
+      argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]);
+}
 
-    if (ret < 0) {
-      caml_acquire_runtime_system();
-      ocaml_avutil_raise_error(ret);
-    }
-
-    // Create the FIFO buffer based on the specified output sample format.
-    ctx->audio_fifo = av_audio_fifo_alloc(ctx->codec_context->sample_fmt,
-                                          ctx->codec_context->channels, 1);
-
-    if (!ctx->audio_fifo) {
-      caml_acquire_runtime_system();
-      caml_raise_out_of_memory();
-    }
-  }
+CAMLprim value ocaml_avcodec_frame_size(value _ctx) {
+  CAMLparam1(_ctx);
+  codec_context_t *ctx = CodecContext_val(_ctx);
+  CAMLreturn(Val_int(ctx->codec_context->frame_size));
 }
 
 CAMLprim value ocaml_avcodec_send_packet(value _ctx, value _packet) {
@@ -509,119 +488,20 @@ CAMLprim value ocaml_avcodec_flush_decoder(value _ctx) {
   return Val_unit;
 }
 
-static void send_audio_fifo_frame(codec_context_t *ctx) {
-  AVFrame *frame = ctx->enc_frame;
-  int frame_size = ctx->codec_context->frame_size;
-  AVAudioFifo *fifo = ctx->audio_fifo;
+static int send_frame(codec_context_t *ctx, AVFrame *frame) {
   int ret;
 
-  caml_release_runtime_system();
-  int fifo_size = av_audio_fifo_size(fifo);
-  caml_acquire_runtime_system();
-
-  if (fifo_size < frame_size) {
-    if (ctx->flushed)
-      frame_size = fifo_size;
-    else
-      return;
-  }
-
-  if (fifo_size > 0) {
-    caml_release_runtime_system();
-    ret = av_frame_make_writable(frame);
-    caml_acquire_runtime_system();
-
-    if (ret < 0)
-      ocaml_avutil_raise_error(ret);
-
-    caml_release_runtime_system();
-    int read_size = av_audio_fifo_read(fifo, (void **)frame->data, frame_size);
-    caml_acquire_runtime_system();
-
-    if (read_size < frame_size) {
-      return ocaml_avutil_raise_error(AVERROR_EXTERNAL);
-    }
-    frame->nb_samples = frame_size;
-    frame->pts = ctx->pts;
-    ctx->pts += frame_size;
-  } else {
-    frame = NULL;
-  }
+  ctx->flushed = !frame;
 
   caml_release_runtime_system();
   ret = avcodec_send_frame(ctx->codec_context, frame);
   caml_acquire_runtime_system();
 
+  if (ret == AVERROR(EAGAIN))
+    return ret;
+
   if (ret < 0)
     ocaml_avutil_raise_error(ret);
-}
-
-static int send_frame(codec_context_t *ctx, AVFrame *frame) {
-  int ret;
-
-  if (!ctx->codec_context)
-    open_codec(ctx, frame);
-
-  ctx->flushed = !frame;
-
-  if (ctx->codec->type == AVMEDIA_TYPE_VIDEO) {
-    if (frame) {
-      frame->pts = ctx->pts++;
-    }
-    caml_release_runtime_system();
-    ret = avcodec_send_frame(ctx->codec_context, frame);
-    caml_acquire_runtime_system();
-
-    if (ret == AVERROR(EAGAIN))
-      return ret;
-
-    if (ret < 0)
-      ocaml_avutil_raise_error(ret);
-  } else if (ctx->audio_fifo == NULL) {
-
-    if (frame) {
-      frame->pts = ctx->pts;
-      ctx->pts += frame->nb_samples;
-    }
-
-    caml_release_runtime_system();
-    ret = avcodec_send_frame(ctx->codec_context, frame);
-    caml_acquire_runtime_system();
-
-    if (ret == AVERROR(EAGAIN))
-      return ret;
-
-    if (ret < 0)
-      ocaml_avutil_raise_error(ret);
-  } else {
-    if (frame != NULL) {
-      AVAudioFifo *fifo = ctx->audio_fifo;
-      int fifo_size = av_audio_fifo_size(fifo);
-
-      fifo_size += frame->nb_samples;
-
-      caml_release_runtime_system();
-      ret = av_audio_fifo_realloc(fifo, fifo_size);
-      caml_acquire_runtime_system();
-
-      if (ret < 0)
-        ocaml_avutil_raise_error(ret);
-
-      // Store the new samples in the FIFO buffer.
-      caml_release_runtime_system();
-      ret = av_audio_fifo_write(fifo,
-                                (void **)(const uint8_t **)frame->extended_data,
-                                frame->nb_samples);
-      caml_acquire_runtime_system();
-
-      if (ret == AVERROR(EAGAIN))
-        return ret;
-
-      if (ret < frame->nb_samples)
-        Fail("Invalid number of samples written to audio fifo queue");
-    }
-    send_audio_fifo_frame(ctx);
-  }
 
   return 0;
 }
@@ -653,16 +533,9 @@ CAMLprim value ocaml_avcodec_receive_packet(value _ctx) {
   if (!packet)
     caml_raise_out_of_memory();
 
-  for (; packet && ret >= 0;) {
-    caml_release_runtime_system();
-    ret = avcodec_receive_packet(ctx->codec_context, packet);
-    caml_acquire_runtime_system();
-
-    if (ret == AVERROR(EAGAIN) && ctx->audio_fifo) {
-      send_audio_fifo_frame(ctx);
-    } else
-      break;
-  }
+  caml_release_runtime_system();
+  ret = avcodec_receive_packet(ctx->codec_context, packet);
+  caml_acquire_runtime_system();
 
   if (ret < 0) {
     caml_release_runtime_system();
@@ -749,6 +622,27 @@ CAMLprim value ocaml_avcodec_find_audio_encoder(value _name) {
 CAMLprim value ocaml_avcodec_find_audio_decoder(value _name) {
   CAMLparam1(_name);
   CAMLreturn((value)find_decoder(String_val(_name), AVMEDIA_TYPE_AUDIO));
+}
+
+CAMLprim value ocaml_avcodec_capabilities(value _codec) {
+  CAMLparam0();
+  CAMLlocal1(ret);
+  AVCodec *codec = (AVCodec *)_codec;
+  int i, len;
+
+  len = 0;
+  for (i = 0; i < AV_CODEC_CAP_T_TAB_LEN; i++)
+    if (codec->capabilities & AV_CODEC_CAP_T_TAB[i][1])
+      len++;
+
+  ret = caml_alloc_tuple(len);
+
+  len = 0;
+  for (i = 0; i < AV_CODEC_CAP_T_TAB_LEN; i++)
+    if (codec->capabilities & AV_CODEC_CAP_T_TAB[i][1])
+      Store_field(ret, len++, Val_int(AV_CODEC_CAP_T_TAB[i][0]));
+
+  CAMLreturn(ret);
 }
 
 CAMLprim value ocaml_avcodec_get_supported_channel_layouts(value _codec) {

--- a/avcodec/config/discover.ml
+++ b/avcodec/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libavcodec"
-                  ~expr:"libavcodec >= 58.18.100"
+                  ~expr:"libavcodec >= 57.107.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/avcodec/dune
+++ b/avcodec/dune
@@ -20,6 +20,17 @@
   (run ./config/discover.exe)))
 
 (rule
+ (targets codec_capabilities_stubs.h)
+ (action
+  (run ../gen_code/gen_code.exe codec_capabilities h)))
+
+(rule
+ (targets codec_capabilities.ml)
+ (deps codec_capabilities_stubs.h)
+ (action
+  (run ../gen_code/gen_code.exe codec_capabilities ml)))
+
+(rule
  (targets codec_id_stubs.h)
  (action
   (run ../gen_code/gen_code.exe codec_id h)))

--- a/avdevice/config/discover.ml
+++ b/avdevice/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libavdevice"
-                  ~expr:"libavdevice >= 58.3.100"
+                  ~expr:"libavdevice >= 57.10.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/avfilter/avfilter.ml
+++ b/avfilter/avfilter.ml
@@ -145,6 +145,8 @@ let filters, abuffer, buffer, abuffersink, buffersink =
     get_some abuffersink,
     get_some buffersink )
 
+let find name = List.find (fun f -> f.name = name) filters
+let find_opt name = List.find_opt (fun f -> f.name = name) filters
 let pad_name { pad_name; _ } = pad_name
 
 external init : unit -> _config = "ocaml_avfilter_init"
@@ -333,25 +335,76 @@ let launch graph =
   { outputs; inputs }
 
 module Utils = struct
-  let split_frame_size ~sample_rate ~time_base ~channels ~channel_layout
-      ~sample_format frame_size =
-    let args =
+  type audio_params = {
+    sample_rate : int;
+    channel_layout : Avutil.Channel_layout.t;
+    sample_format : Avutil.Sample_format.t;
+  }
+
+  let convert_audio ?out_params ?out_frame_size ~in_time_base ~in_params () =
+    let abuffer_args =
       [
-        `Pair ("sample_rate", `Int sample_rate);
-        `Pair ("time_base", `Rational time_base);
-        `Pair ("channels", `Int channels);
+        `Pair ("sample_rate", `Int in_params.sample_rate);
+        `Pair ("time_base", `Rational in_time_base);
         `Pair
-          ("channel_layout", `Int (Avutil.Channel_layout.get_id channel_layout));
-        `Pair ("sample_fmt", `Int (Avutil.Sample_format.get_id sample_format));
+          ( "channel_layout",
+            `Int (Avutil.Channel_layout.get_id in_params.channel_layout) );
+        `Pair
+          ( "sample_fmt",
+            `Int (Avutil.Sample_format.get_id in_params.sample_format) );
       ]
     in
 
     let graph = init () in
-    let abuffer = attach ~args ~name:"abuffer" abuffer graph in
+    let abuffer = attach ~args:abuffer_args ~name:"abuffer" abuffer graph in
+
+    let output =
+      match abuffer.io.outputs.audio with o :: _ -> o | _ -> assert false
+    in
+
+    let output =
+      match out_params with
+        | None -> output
+        | Some out_params ->
+            let aresample = find "aresample" in
+            let args =
+              [
+                `Pair ("in_sample_rate", `Int in_params.sample_rate);
+                `Pair
+                  ( "in_channel_layout",
+                    `Int (Avutil.Channel_layout.get_id in_params.channel_layout)
+                  );
+                `Pair
+                  ( "in_sample_fmt",
+                    `Int (Avutil.Sample_format.get_id in_params.sample_format)
+                  );
+                `Pair ("out_sample_rate", `Int out_params.sample_rate);
+                `Pair
+                  ( "out_channel_layout",
+                    `Int
+                      (Avutil.Channel_layout.get_id out_params.channel_layout)
+                  );
+                `Pair
+                  ( "out_sample_fmt",
+                    `Int (Avutil.Sample_format.get_id out_params.sample_format)
+                  );
+              ]
+            in
+            let aresample = attach ~args ~name:"aresample" aresample graph in
+            let ainput, aoutput =
+              match (aresample.io.inputs.audio, aresample.io.outputs.audio) with
+                | i :: _, o :: _ -> (i, o)
+                | _ -> assert false
+            in
+            link output ainput;
+            aoutput
+    in
+
     let abuffersink = attach ~name:"sink" abuffersink graph in
+
     let () =
-      match (abuffer.io.outputs.audio, abuffersink.io.inputs.audio) with
-        | o :: _, i :: _ -> link o i
+      match abuffersink.io.inputs.audio with
+        | input :: _ -> link output input
         | _ -> assert false
     in
     let filter = launch graph in
@@ -360,6 +413,10 @@ module Utils = struct
         | (_, i) :: _, (_, o) :: _ -> (i, o)
         | _ -> assert false
     in
-    set_frame_size filter_out.context frame_size;
+    let () =
+      match out_frame_size with
+        | None -> ()
+        | Some frame_size -> set_frame_size filter_out.context frame_size
+    in
     (filter_in, filter_out.handler)
 end

--- a/avfilter/avfilter.ml
+++ b/avfilter/avfilter.ml
@@ -67,6 +67,9 @@ external channel_layout : filter_ctx -> Avutil.Channel_layout.t
 external sample_rate : filter_ctx -> int
   = "ocaml_avfilter_buffersink_get_sample_rate"
 
+external set_frame_size : filter_ctx -> int -> unit
+  = "ocaml_avfilter_buffersink_set_frame_size"
+
 exception Exists
 
 type ('a, 'b, 'c) _filter = {
@@ -328,3 +331,35 @@ let launch graph =
   in
   let outputs = { audio; video } in
   { outputs; inputs }
+
+module Utils = struct
+  let split_frame_size ~sample_rate ~time_base ~channels ~channel_layout
+      ~sample_format frame_size =
+    let args =
+      [
+        `Pair ("sample_rate", `Int sample_rate);
+        `Pair ("time_base", `Rational time_base);
+        `Pair ("channels", `Int channels);
+        `Pair
+          ("channel_layout", `Int (Avutil.Channel_layout.get_id channel_layout));
+        `Pair ("sample_fmt", `Int (Avutil.Sample_format.get_id sample_format));
+      ]
+    in
+
+    let graph = init () in
+    let abuffer = attach ~args ~name:"abuffer" abuffer graph in
+    let abuffersink = attach ~name:"sink" abuffersink graph in
+    let () =
+      match (abuffer.io.outputs.audio, abuffersink.io.inputs.audio) with
+        | o :: _, i :: _ -> link o i
+        | _ -> assert false
+    in
+    let filter = launch graph in
+    let filter_in, filter_out =
+      match (filter.inputs.audio, filter.outputs.audio) with
+        | (_, i) :: _, (_, o) :: _ -> (i, o)
+        | _ -> assert false
+    in
+    set_frame_size filter_out.context frame_size;
+    (filter_in, filter_out.handler)
+end

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -40,6 +40,7 @@ val sample_aspect_ratio : [ `Video ] context -> Avutil.rational
 val channels : [ `Audio ] context -> int
 val channel_layout : [ `Audio ] context -> Avutil.Channel_layout.t
 val sample_rate : [ `Audio ] context -> int
+val set_frame_size : [ `Audio ] context -> int -> unit
 
 exception Exists
 
@@ -97,3 +98,16 @@ val parse :
 (** Check validity and configure all the links and formats in the graph and
     return its outputs and outputs. *)
 val launch : config -> t
+
+module Utils : sig
+  (** Returns a pair of input/output functions that can be used to split frames
+      into fixed sizes. *)
+  val split_frame_size :
+    sample_rate:int ->
+    time_base:Avutil.rational ->
+    channels:int ->
+    channel_layout:Avutil.Channel_layout.t ->
+    sample_format:Avutil.Sample_format.t ->
+    int ->
+    ('a Avutil.frame -> unit) * (unit -> 'b Avutil.frame)
+end

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -47,6 +47,9 @@ exception Exists
 (** Filter list. *)
 val filters : [ `Unattached ] filter list
 
+val find : string -> [ `Unattached ] filter
+val find_opt : string -> [ `Unattached ] filter option
+
 (** Buffers (input). *)
 val abuffer : [ `Unattached ] filter
 
@@ -100,14 +103,17 @@ val parse :
 val launch : config -> t
 
 module Utils : sig
-  (** Returns a pair of input/output functions that can be used to split frames
-      into fixed sizes. *)
-  val split_frame_size :
-    sample_rate:int ->
-    time_base:Avutil.rational ->
-    channels:int ->
-    channel_layout:Avutil.Channel_layout.t ->
-    sample_format:Avutil.Sample_format.t ->
-    int ->
+  type audio_params = {
+    sample_rate : int;
+    channel_layout : Avutil.Channel_layout.t;
+    sample_format : Avutil.Sample_format.t;
+  }
+
+  val convert_audio :
+    ?out_params:audio_params ->
+    ?out_frame_size:int ->
+    in_time_base:Avutil.rational ->
+    in_params:audio_params ->
+    unit ->
     ('a Avutil.frame -> unit) * (unit -> 'b Avutil.frame)
 end

--- a/avfilter/avfilter_stubs.c
+++ b/avfilter/avfilter_stubs.c
@@ -397,6 +397,17 @@ CAMLprim value ocaml_avfilter_buffersink_get_sample_rate(value _src) {
   CAMLreturn(Val_int(sample_rate));
 }
 
+CAMLprim value ocaml_avfilter_buffersink_set_frame_size(value _src,
+                                                        value _size) {
+  CAMLparam0();
+
+  caml_release_runtime_system();
+  av_buffersink_set_frame_size((AVFilterContext *)_src, Int_val(_size));
+  caml_acquire_runtime_system();
+
+  CAMLreturn(Val_unit);
+}
+
 CAMLprim value ocaml_avfilter_config(value _graph) {
   CAMLparam1(_graph);
 

--- a/avfilter/config/discover.ml
+++ b/avfilter/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libavfilter"
-                  ~expr:"libavfilter >= 7.16.100"
+                  ~expr:"libavfilter >= 6.107.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -24,9 +24,9 @@ type ('line, 'media) format
 (* Frame *)
 type 'media frame
 
-external frame_pts : _ frame -> Int64.t = "ocaml_avutil_frame_pts"
+external frame_pts : _ frame -> Int64.t option = "ocaml_avutil_frame_pts"
 
-external frame_set_pts : _ frame -> Int64.t -> unit
+external frame_set_pts : _ frame -> Int64.t option -> unit
   = "ocaml_avutil_frame_set_pts"
 
 type error =

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -175,6 +175,9 @@ module Audio = struct
 
   external frame_get_channels : audio frame -> int
     = "ocaml_avutil_audio_frame_get_channels"
+
+  external frame_nb_samples : audio frame -> int
+    = "ocaml_avutil_audio_frame_nb_samples"
 end
 
 module Video = struct

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -47,6 +47,7 @@ type error =
   | `Eagain
   | `Unknown
   | `Experimental
+  | `Other of int
   | `Failure of string ]
 
 external string_of_error : error -> string = "ocaml_avutil_string_of_error"
@@ -175,6 +176,9 @@ module Audio = struct
 
   external frame_get_channels : audio frame -> int
     = "ocaml_avutil_audio_frame_get_channels"
+
+  external frame_get_channel_layout : audio frame -> Channel_layout.t
+    = "ocaml_avutil_audio_frame_get_channel_layout"
 
   external frame_nb_samples : audio frame -> int
     = "ocaml_avutil_audio_frame_nb_samples"

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -81,6 +81,8 @@ let create_data len =
 
 type rational = { num : int; den : int }
 
+let string_of_rational { num; den } = Printf.sprintf "%d/%d" num den
+
 external time_base : unit -> rational = "ocaml_avutil_time_base"
 
 module Time_format = struct

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -183,6 +183,10 @@ module Audio : sig
   (** [Avutil.Audio.frame_get_channels frame] returns the number of audio
       channels in the current frame. *)
   val frame_get_channels : audio frame -> int
+
+  (** [Avutil.Audio.frame_nb_samples frame] returns the number of audio samples
+      per channel in the current frame. *)
+  val frame_nb_samples : audio frame -> int
 end
 
 module Video : sig

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -74,6 +74,8 @@ val create_data : int -> data
 
 type rational = { num : int; den : int }
 
+val string_of_rational : rational -> string
+
 (** {9 Timestamp} *)
 
 (** Formats for time. *)

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -33,10 +33,10 @@ type 'media frame
 
 (** [Avutil.frame_pts frame] returns the presentation timestamp in time_base
     units (time when frame should be shown to user). *)
-val frame_pts : _ frame -> Int64.t
+val frame_pts : _ frame -> Int64.t option
 
 (** [Avutil.frame_set_pts frame pts] sets the presentation time for this frame. *)
-val frame_set_pts : _ frame -> Int64.t -> unit
+val frame_set_pts : _ frame -> Int64.t option -> unit
 
 (** {1 Exception} *)
 

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -59,6 +59,7 @@ type error =
   | `Eagain
   | `Unknown
   | `Experimental
+  | `Other of int
   | (* `Failure is for errors from the binding code itself. *)
     `Failure of string ]
 
@@ -183,6 +184,10 @@ module Audio : sig
   (** [Avutil.Audio.frame_get_channels frame] returns the number of audio
       channels in the current frame. *)
   val frame_get_channels : audio frame -> int
+
+  (** [Avutil.Audio.frame_get_channel_layout frame] returns the channel layout
+      for the current frame. *)
+  val frame_get_channel_layout : audio frame -> Channel_layout.t
 
   (** [Avutil.Audio.frame_nb_samples frame] returns the number of audio samples
       per channel in the current frame. *)

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -537,7 +537,8 @@ CAMLprim value ocaml_avutil_frame_pts(value _frame) {
   CAMLlocal1(ret);
   AVFrame *frame = Frame_val(_frame);
 
-  if (frame->pts == AV_NOPTS_VALUE) CAMLreturn(Val_none);
+  if (frame->pts == AV_NOPTS_VALUE)
+    CAMLreturn(Val_none);
 
   ret = caml_alloc_tuple(1);
   Store_field(ret, 0, caml_copy_int64(frame->pts));
@@ -603,6 +604,13 @@ CAMLprim value ocaml_avutil_audio_frame_get_channels(value _frame) {
   AVFrame *frame = Frame_val(_frame);
 
   CAMLreturn(Val_int(frame->channels));
+}
+
+CAMLprim value ocaml_avutil_audio_frame_nb_samples(value _frame) {
+  CAMLparam1(_frame);
+  AVFrame *frame = Frame_val(_frame);
+
+  CAMLreturn(Val_int(frame->nb_samples));
 }
 
 CAMLprim value ocaml_avutil_video_frame_width(value _frame) {

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -534,16 +534,25 @@ value value_of_frame(AVFrame *frame) {
 
 CAMLprim value ocaml_avutil_frame_pts(value _frame) {
   CAMLparam1(_frame);
+  CAMLlocal1(ret);
   AVFrame *frame = Frame_val(_frame);
 
-  CAMLreturn(caml_copy_int64(frame->pts));
+  if (frame->pts == AV_NOPTS_VALUE) CAMLreturn(Val_none);
+
+  ret = caml_alloc_tuple(1);
+  Store_field(ret, 0, caml_copy_int64(frame->pts));
+
+  CAMLreturn(ret);
 }
 
 CAMLprim value ocaml_avutil_frame_set_pts(value _frame, value _pts) {
   CAMLparam2(_frame, _pts);
-
   AVFrame *frame = Frame_val(_frame);
-  frame->pts = Int64_val(_pts);
+
+  if (_pts == Val_none)
+    frame->pts = AV_NOPTS_VALUE;
+  else
+    frame->pts = Int64_val(Field(_pts, 0));
 
   CAMLreturn(Val_unit);
 }

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -22,7 +22,7 @@
 char ocaml_av_exn_msg[ERROR_MSG_SIZE + 1];
 
 void ocaml_avutil_raise_error(int err) {
-  int _err = 0;
+  value _err;
 
   switch (err) {
   case AVERROR_BSF_NOT_FOUND:
@@ -77,7 +77,9 @@ void ocaml_avutil_raise_error(int err) {
     _err = PVV_Experimental;
     break;
   default:
-    Fail("%s", av_err2str(err));
+    _err = caml_alloc_tuple(2);
+    Store_field(_err, 0, PVV_Other);
+    Store_field(_err, 1, Val_int(err));
   }
 
   caml_raise_with_arg(*caml_named_value(EXN_ERROR), _err);
@@ -140,8 +142,11 @@ CAMLprim value ocaml_avutil_string_of_error(value error) {
     err = AVERROR_EXPERIMENTAL;
     break;
   default:
-    // Failure error is a 2-uple with string as second entry.
-    CAMLreturn(Field(error, 1));
+    if (Field(error, 0) == PVV_Other)
+      err = Int_val(Field(error, 1));
+    else
+      // Failure
+      CAMLreturn(Field(error, 1));
   }
 
   CAMLreturn(caml_copy_string(av_err2str(err)));
@@ -604,6 +609,13 @@ CAMLprim value ocaml_avutil_audio_frame_get_channels(value _frame) {
   AVFrame *frame = Frame_val(_frame);
 
   CAMLreturn(Val_int(frame->channels));
+}
+
+CAMLprim value ocaml_avutil_audio_frame_get_channel_layout(value _frame) {
+  CAMLparam1(_frame);
+  AVFrame *frame = Frame_val(_frame);
+
+  CAMLreturn(Val_ChannelLayout((frame->channel_layout)));
 }
 
 CAMLprim value ocaml_avutil_audio_frame_nb_samples(value _frame) {

--- a/avutil/config/discover.ml
+++ b/avutil/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libavutil libavcodec"
-                  ~expr:"libavutil >= 56.14.100, libavcodec >= 58.18.100"
+                  ~expr:"libavutil >= 55.78.100, libavcodec >= 57.107.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/examples/aresample.ml
+++ b/examples/aresample.ml
@@ -18,6 +18,12 @@ let () =
     (params, audio_input, (i, Av.new_audio_stream ~codec:audio_codec ~opts dst))
   in
 
+  let frame_size =
+    if List.mem `Variable_frame_size (Avcodec.Audio.capabilities audio_codec)
+    then 512
+    else Av.get_frame_size (snd oass)
+  in
+
   let filter =
     let config = Avfilter.init () in
     let abuffer =
@@ -65,6 +71,7 @@ let () =
 
   let _, output = List.hd Avfilter.(filter.outputs.audio) in
   let context = output.context in
+  Avfilter.set_frame_size context frame_size;
   let time_base = Avfilter.time_base context in
   Printf.printf
     "Sink info:\n\

--- a/examples/aresample.ml
+++ b/examples/aresample.ml
@@ -14,8 +14,16 @@ let () =
 
   let audio_params, audio_input, oass =
     Av.find_best_audio_stream src |> fun (i, audio_input, params) ->
-    let opts = Av.mk_audio_opts ~params () in
-    (params, audio_input, (i, Av.new_audio_stream ~codec:audio_codec ~opts dst))
+    let channel_layout = Avcodec.Audio.get_channel_layout params in
+    let channels = Avcodec.Audio.get_nb_channels params in
+    let sample_format = Avcodec.Audio.get_sample_format params in
+    let sample_rate = Avcodec.Audio.get_sample_rate params in
+    let time_base = { Avutil.num = 1; den = sample_rate } in
+    ( params,
+      audio_input,
+      ( i,
+        Av.new_audio_stream ~channels ~channel_layout ~sample_format
+          ~sample_rate ~time_base ~codec:audio_codec dst ) )
   in
 
   let frame_size =

--- a/examples/decode_audio.ml
+++ b/examples/decode_audio.ml
@@ -33,12 +33,14 @@ let () =
   let in_fd = Unix.openfile Sys.argv.(1) [Unix.O_RDONLY] 0 in
 
   let out_file = Av.open_output Sys.argv.(3) in
-  let out_codec = Avcodec.Audio.find_encoder Sys.argv.(4) in
-  let out_stream = Av.new_audio_stream ~codec:out_codec out_file in
-
-  let frame_size =
-    if List.mem `Variable_frame_size (Audio.capabilities out_codec) then 512
-    else Av.get_frame_size out_stream
+  let codec = Avcodec.Audio.find_encoder Sys.argv.(4) in
+  let channel_layout = Avcodec.Audio.find_best_channel_layout codec `Stereo in
+  let sample_format = Avcodec.Audio.find_best_sample_format codec `Dbl in
+  let sample_rate = Avcodec.Audio.find_best_sample_rate codec 44100 in
+  let time_base = { Avutil.num = 1; den = sample_rate } in
+  let out_stream =
+    Av.new_audio_stream ~channel_layout ~sample_format ~sample_rate ~time_base
+      ~codec out_file
   in
 
   let filters = ref None in
@@ -46,14 +48,26 @@ let () =
     match !filters with
       | Some f -> f
       | None ->
-          let sample_rate = Avutil.Audio.frame_get_sample_rate frame in
-          let time_base = { Avutil.num = 1; den = sample_rate } in
-          let channels = Avutil.Audio.frame_get_channels frame in
-          let channel_layout = Avutil.Audio.frame_get_channel_layout frame in
-          let sample_format = Avutil.Audio.frame_get_sample_format frame in
+          let in_params =
+            {
+              Avfilter.Utils.sample_rate =
+                Avutil.Audio.frame_get_sample_rate frame;
+              channel_layout = Avutil.Audio.frame_get_channel_layout frame;
+              sample_format = Avutil.Audio.frame_get_sample_format frame;
+            }
+          in
+          let in_time_base = { Avutil.num = 1; den = sample_rate } in
+          let out_frame_size =
+            if List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec)
+            then 512
+            else Av.get_frame_size out_stream
+          in
+          let out_params =
+            { Avfilter.Utils.sample_rate; sample_format; channel_layout }
+          in
           let f =
-            Avfilter.Utils.split_frame_size ~sample_rate ~time_base ~channels
-              ~channel_layout ~sample_format frame_size
+            Avfilter.Utils.convert_audio ~in_params ~in_time_base ~out_params
+              ~out_frame_size ()
           in
           filters := Some f;
           f

--- a/examples/decode_stream.ml
+++ b/examples/decode_stream.ml
@@ -19,6 +19,46 @@ let () =
   let codec = Avcodec.Audio.find_encoder Sys.argv.(3) in
   let out_stream = Av.new_audio_stream ~codec out_file in
 
+  let frame_size =
+    if List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec) then 512
+    else Av.get_frame_size out_stream
+  in
+
+  let filters = ref None in
+  let get_filters frame =
+    match !filters with
+      | Some f -> f
+      | None ->
+          let sample_rate = Avutil.Audio.frame_get_sample_rate frame in
+          let time_base = { Avutil.num = 1; den = sample_rate } in
+          let channels = Avutil.Audio.frame_get_channels frame in
+          let channel_layout = Avutil.Audio.frame_get_channel_layout frame in
+          let sample_format = Avutil.Audio.frame_get_sample_format frame in
+          let f =
+            Avfilter.Utils.split_frame_size ~sample_rate ~time_base ~channels
+              ~channel_layout ~sample_format frame_size
+          in
+          filters := Some f;
+          f
+  in
+
+  let pts = ref 0L in
+  let rec flush filter_out =
+    try
+      filter_out () |> fun frame ->
+      Avutil.frame_set_pts frame (Some !pts);
+      pts := Int64.add !pts (Int64.of_int (Avutil.Audio.frame_nb_samples frame));
+      Av.write_frame out_stream frame;
+      flush filter_out
+    with Avutil.Error `Eagain -> ()
+  in
+
+  let write_frame frame =
+    let filter_in, filter_out = get_filters frame in
+    filter_in frame;
+    flush filter_out
+  in
+
   let read = Unix.read in_fd in
   let seek = Unix.lseek in_fd in
   let container = Av.open_input_stream ~seek read in
@@ -47,7 +87,7 @@ let () =
     sample_format;
   let rec f () =
     try
-      Av.write_frame out_stream (Av.read_frame stream);
+      write_frame (Av.read_frame stream);
       f ()
     with
       | Avutil.Error `Eof -> ()

--- a/examples/dune
+++ b/examples/dune
@@ -21,12 +21,12 @@
 (executable
  (name decode_audio)
  (modules decode_audio)
- (libraries ffmpeg-av))
+ (libraries ffmpeg-av ffmpeg-avfilter))
 
 (executable
  (name decode_stream)
  (modules decode_stream)
- (libraries ffmpeg-av))
+ (libraries ffmpeg-av ffmpeg-avfilter))
 
 (executable
  (name demuxing_decoding)
@@ -41,7 +41,7 @@
 (executable
  (name encode_stream)
  (modules encode_stream)
- (libraries ffmpeg-av ffmpeg-swresample))
+ (libraries ffmpeg-av ffmpeg-avfilter ffmpeg-swresample))
 
 (executable
  (name encode_video)

--- a/examples/encode_audio.ml
+++ b/examples/encode_audio.ml
@@ -14,10 +14,19 @@ let () =
 
   let pi = 4.0 *. atan 1.0 in
   let sample_rate = 44100 in
-  let frame_size = 512 in
 
   let codec = Audio.find_encoder Sys.argv.(2) in
-  let encoder = Audio.create_encoder codec in
+  let out_sample_format = Audio.find_best_sample_format codec `Dbl in
+  let encoder =
+    Audio.create_encoder ~channel_layout:`Stereo ~channels:2
+      ~sample_format:out_sample_format ~sample_rate codec
+  in
+
+  let frame_size =
+    if List.mem `Variable_frame_size (Audio.capabilities codec) then 512
+    else Audio.frame_size encoder
+  in
+
   let out_sample_format = Audio.find_best_sample_format codec `Dbl in
 
   let rsp =

--- a/examples/encode_stream.ml
+++ b/examples/encode_stream.ml
@@ -14,7 +14,6 @@ let () =
 
   let pi = 4.0 *. atan 1.0 in
   let sample_rate = 44100 in
-  let frame_size = 512 in
 
   let codec = Audio.find_encoder Sys.argv.(2) in
   let out_sample_format = Audio.find_best_sample_format codec `Dbl in
@@ -44,14 +43,22 @@ let () =
 
   let output = Av.open_output_stream ~opts:output_opt ~seek write format in
 
+  let pts = ref 0L in
+  let time_base = { Avutil.num = 1; den = out_sample_rate } in
+
   let opts =
-    Av.mk_audio_opts ~channels:2 ~sample_format:out_sample_format
+    Av.mk_audio_opts ~channels:2 ~time_base ~sample_format:out_sample_format
       ~sample_rate:out_sample_rate ()
   in
   Hashtbl.add opts "lpc_type" (`String "none");
   Hashtbl.add opts "foo" (`String "bla");
 
   let stream = Av.new_audio_stream ~codec ~opts output in
+
+  let frame_size =
+    if List.mem `Variable_frame_size (Audio.capabilities codec) then 512
+    else Av.get_frame_size stream
+  in
 
   assert (Hashtbl.mem opts "foo");
   if Sys.argv.(2) = "flac" then assert (not (Hashtbl.mem opts "lpc_type"))
@@ -63,7 +70,11 @@ let () =
   for i = 0 to 2000 do
     Array.init frame_size (fun t ->
         sin (float_of_int (t + (i * frame_size)) *. c))
-    |> Resampler.convert rsp |> Av.write_frame stream
+    |> Resampler.convert rsp
+    |> fun frame ->
+    Avutil.frame_set_pts frame (Some !pts);
+    pts := Int64.add !pts (Int64.of_int (Avutil.Audio.frame_nb_samples frame));
+    Av.write_frame stream frame
   done;
 
   Av.close output;

--- a/examples/encode_video.ml
+++ b/examples/encode_video.ml
@@ -40,16 +40,14 @@ let () =
 
   let dst = Av.open_output Sys.argv.(1) in
 
-  let frame_rate = 25 in
-  let time_base = { Avutil.num = 1; den = frame_rate } in
+  let frame_rate = { Avutil.num = 25; den = 1 } in
+  let time_base = { Avutil.num = 1; den = 25 } in
   let pts = ref 0L in
 
-  let opts =
-    Av.mk_video_opts ~size:(width, height) ~frame_rate ~time_base ~pixel_format
-      ()
+  let ovs =
+    Av.new_video_stream ~width ~height ~frame_rate ~time_base ~pixel_format
+      ~codec dst
   in
-
-  let ovs = Av.new_video_stream ~codec ~opts dst in
 
   let frame = Video.create_frame width height pixel_format in
 

--- a/examples/encode_video.ml
+++ b/examples/encode_video.ml
@@ -40,7 +40,14 @@ let () =
 
   let dst = Av.open_output Sys.argv.(1) in
 
-  let opts = Av.mk_video_opts ~size:(width, height) ~pixel_format () in
+  let frame_rate = 25 in
+  let time_base = { Avutil.num = 1; den = frame_rate } in
+  let pts = ref 0L in
+
+  let opts =
+    Av.mk_video_opts ~size:(width, height) ~frame_rate ~time_base ~pixel_format
+      ()
+  in
 
   let ovs = Av.new_video_stream ~codec ~opts dst in
 
@@ -48,7 +55,10 @@ let () =
 
   for i = 0 to 240 do
     Video.frame_visit ~make_writable:true (fill_yuv_image width height i) frame
-    |> Av.write_frame ovs
+    |> fun frame ->
+    Avutil.frame_set_pts frame (Some !pts);
+    pts := Int64.succ !pts;
+    Av.write_frame ovs frame
   done;
 
   Av.close dst;

--- a/examples/encoding.ml
+++ b/examples/encoding.ml
@@ -65,6 +65,7 @@ let () =
   in
 
   let oas = Av.new_audio_stream ~codec ~opts dst in
+  let audio_frame_size = Av.get_frame_size oas in
 
   Av.set_metadata oas [("Media", "Audio")];
 
@@ -74,7 +75,8 @@ let () =
 
   let audio_on_off =
     [|
-      Array.init 1804 (fun t -> sin (float_of_int t *. c)); Array.make 1804 0.;
+      Array.init audio_frame_size (fun t -> sin (float_of_int t *. c));
+      Array.make audio_frame_size 0.;
     |]
   in
 

--- a/examples/fps.ml
+++ b/examples/fps.ml
@@ -15,14 +15,29 @@ let () =
 
   let oass =
     Av.find_best_audio_stream src |> fun (i, _, params) ->
-    let opts = Av.mk_audio_opts ~params () in
-    (i, Av.new_audio_stream ~codec:audio_codec ~opts dst)
+    let channel_layout = Avcodec.Audio.get_channel_layout params in
+    let channels = Avcodec.Audio.get_nb_channels params in
+    let sample_format = Avcodec.Audio.get_sample_format params in
+    let sample_rate = Avcodec.Audio.get_sample_rate params in
+    let time_base = { Avutil.num = 1; den = sample_rate } in
+    ( i,
+      Av.new_audio_stream ~channels ~channel_layout ~sample_format ~sample_rate
+        ~time_base ~codec:audio_codec dst )
   in
+
+  let frame_rate = { Avutil.num = 25; den = 1 } in
+  let time_base = { Avutil.num = 1; den = 25 } in
 
   let video_params, video_input, ovss =
     Av.find_best_video_stream src |> fun (i, video_input, params) ->
-    let opts = Av.mk_video_opts ~params () in
-    (params, video_input, (i, Av.new_video_stream ~codec:video_codec ~opts dst))
+    let width = Avcodec.Video.get_width params in
+    let height = Avcodec.Video.get_height params in
+    let pixel_format = Avcodec.Video.get_pixel_format params in
+    ( params,
+      video_input,
+      ( i,
+        Av.new_video_stream ~pixel_format ~frame_rate ~time_base ~width ~height
+          ~codec:video_codec dst ) )
   in
 
   let filter =
@@ -44,11 +59,17 @@ let () =
       Avfilter.(attach ~args ~name:"buffer" buffer config)
     in
     let fps =
-      let args = [`Pair ("fps", `Int 25)] in
-      let buffer =
-        List.find (fun { Avfilter.name; _ } -> name = "fps") Avfilter.filters
+      let args =
+        [
+          `Pair
+            ( "fps",
+              `String
+                (Printf.sprintf "%d/%d" frame_rate.Avutil.num
+                   frame_rate.Avutil.den) );
+        ]
       in
-      Avfilter.attach ~args ~name:"fps" buffer config
+      let fps = Avfilter.find "fps" in
+      Avfilter.attach ~args ~name:"fps" fps config
     in
     let sink = Avfilter.(attach ~name:"sink" buffersink config) in
     Avfilter.link

--- a/examples/remuxing.ml
+++ b/examples/remuxing.ml
@@ -22,8 +22,14 @@ let () =
            let codec =
              Avcodec.Audio.find_encoder (Avcodec.Audio.string_of_id id)
            in
-           let opts = Av.mk_audio_opts ~params () in
-           (i, Av.new_audio_stream ~codec ~opts dst))
+           let channel_layout = Avcodec.Audio.get_channel_layout params in
+           let channels = Avcodec.Audio.get_nb_channels params in
+           let sample_format = Avcodec.Audio.get_sample_format params in
+           let sample_rate = Avcodec.Audio.get_sample_rate params in
+           let time_base = { Avutil.num = 1; den = sample_rate } in
+           ( i,
+             Av.new_audio_stream ~channels ~channel_layout ~sample_format
+               ~sample_rate ~time_base ~codec dst ))
   in
 
   let ovss =
@@ -34,8 +40,14 @@ let () =
            let codec =
              Avcodec.Video.find_encoder (Avcodec.Video.string_of_id id)
            in
-           let opts = Av.mk_video_opts ~params () in
-           (i, Av.new_video_stream ~codec ~opts dst))
+           let width = Avcodec.Video.get_width params in
+           let height = Avcodec.Video.get_height params in
+           let pixel_format = Avcodec.Video.get_pixel_format params in
+           let frame_rate = { Avutil.num = 25; den = 1 } in
+           let time_base = { Avutil.num = 1; den = 25 } in
+           ( i,
+             Av.new_video_stream ~pixel_format ~frame_rate ~time_base ~width
+               ~height ~codec dst ))
   in
 
   let osss =
@@ -46,7 +58,8 @@ let () =
            let codec =
              Avcodec.Subtitle.find_encoder (Avcodec.Subtitle.string_of_id id)
            in
-           (i, Av.new_subtitle_stream ~codec dst))
+           let time_base = { Avutil.num = 1; den = 25 } in
+           (i, Av.new_subtitle_stream ~time_base ~codec dst))
   in
 
   src

--- a/examples/transcode_aac.ml
+++ b/examples/transcode_aac.ml
@@ -12,10 +12,15 @@ let () =
 
   let codec = Avcodec.Audio.find_encoder "aac" in
 
-  let opts = Av.mk_audio_opts ~params () in
+  let channel_layout = Avcodec.Audio.get_channel_layout params in
+  let sample_format = Avcodec.Audio.get_sample_format params in
+  let sample_rate = Avcodec.Audio.get_sample_rate params in
+  let time_base = { Avutil.num = 1; den = sample_rate } in
 
   let ostream =
-    Av.open_output Sys.argv.(2) |> Av.new_audio_stream ~codec ~opts
+    Av.open_output Sys.argv.(2)
+    |> Av.new_audio_stream ~channel_layout ~sample_format ~sample_rate
+         ~time_base ~codec
   in
 
   istream |> Av.iter_frame (Av.write_frame ostream);

--- a/examples/transcoding.ml
+++ b/examples/transcoding.ml
@@ -16,15 +16,27 @@ let () =
   let oass =
     Av.get_audio_streams src
     |> List.map (fun (i, _, params) ->
-           let opts = Av.mk_audio_opts ~params () in
-           (i, Av.new_audio_stream ~codec:audio_codec ~opts dst))
+           let channel_layout = Avcodec.Audio.get_channel_layout params in
+           let sample_format = Avcodec.Audio.get_sample_format params in
+           let sample_rate = Avcodec.Audio.get_sample_rate params in
+           let time_base = { Avutil.num = 1; den = sample_rate } in
+           ( i,
+             Av.new_audio_stream ~channel_layout ~sample_format ~sample_rate
+               ~time_base ~codec:audio_codec dst ))
   in
+
+  let frame_rate = { Avutil.num = 25; den = 1 } in
+  let time_base = { Avutil.num = 1; den = 25 } in
 
   let ovss =
     Av.get_video_streams src
     |> List.map (fun (i, _, params) ->
-           let opts = Av.mk_video_opts ~params () in
-           (i, Av.new_video_stream ~codec:video_codec ~opts dst))
+           let width = Avcodec.Video.get_width params in
+           let height = Avcodec.Video.get_height params in
+           let pixel_format = Avcodec.Video.get_pixel_format params in
+           ( i,
+             Av.new_video_stream ~pixel_format ~frame_rate ~time_base ~width
+               ~height ~codec:video_codec dst ))
   in
 
   let osss =
@@ -35,7 +47,7 @@ let () =
                (Avcodec.Subtitle.string_of_id
                   (Avcodec.Subtitle.get_params_id params))
            in
-           (i, Av.new_subtitle_stream ~codec dst))
+           (i, Av.new_subtitle_stream ~time_base ~codec dst))
   in
 
   src

--- a/ffmpeg-av.opam
+++ b/ffmpeg-av.opam
@@ -33,8 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 depexts: [
-  ["libavutil-dev" "libavformat-dev" "libswresample-dev" "libswscale-dev"]
-    {os-family = "debian"}
+  ["libavutil-dev" "libavformat-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/ffmpeg-av.opam.template
+++ b/ffmpeg-av.opam.template
@@ -1,6 +1,5 @@
 depexts: [
-  ["libavutil-dev" "libavformat-dev" "libswresample-dev" "libswscale-dev"]
-    {os-family = "debian"}
+  ["libavutil-dev" "libavformat-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}

--- a/gen_code/gen_code.ml
+++ b/gen_code/gen_code.ml
@@ -186,6 +186,7 @@ let gen_polymorphic_variant_h () =
       "Eagain";
       "Unknown";
       "Experimental";
+      "Other";
       "Failure";
     ];
 

--- a/gen_code/gen_code.ml
+++ b/gen_code/gen_code.ml
@@ -250,6 +250,19 @@ let gen_channel_layout mode =
     ]
     mode
 
+let gen_codec_capabilities mode =
+  translate_enums "/libavcodec/avcodec.h" "codec_capabilities"
+    [
+      ( "",
+        "#define AV_CODEC_CAP_\\([A-Z0-9_]+\\)",
+        "",
+        "AV_CODEC_CAP_",
+        "uint64_t",
+        "CodecCapabilities",
+        "t" );
+    ]
+    mode
+
 let gen_sample_format mode =
   translate_enums "/libavutil/samplefmt.h" "sample_format"
     [
@@ -299,4 +312,5 @@ let () =
     | "channel_layout" -> gen_channel_layout mode
     | "sample_format" -> gen_sample_format mode
     | "swresample_options" -> gen_swresample_options mode
+    | "codec_capabilities" -> gen_codec_capabilities mode
     | _ -> assert false

--- a/swresample/config/discover.ml
+++ b/swresample/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libswresample"
-                  ~expr:"libswresample >= 3.1.100"
+                  ~expr:"libswresample >= 2.9.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/swresample/swresample.ml
+++ b/swresample/swresample.ml
@@ -323,6 +323,5 @@ module Make (I : AudioData) (O : AudioData) = struct
       ~out_sample_format:(Avcodec.Audio.get_sample_format out_codec)
       (Avcodec.Audio.get_sample_rate out_codec)
 
-  external reuse_output : t -> bool -> unit = "ocaml_swresample_reuse_output"
   external convert : t -> I.t -> O.t = "ocaml_swresample_convert"
 end

--- a/swresample/swresample.mli
+++ b/swresample/swresample.mli
@@ -75,13 +75,6 @@ module Make (I : AudioData) (O : AudioData) : sig
   val from_codec_to_codec :
     ?options:options list -> audio Avcodec.params -> audio Avcodec.params -> t
 
-  (** [Swresample.reuse_output ro] enables or disables the reuse of
-      {!Swresample.convert} output according to the value of [ro]. Reusing the
-      output reduces the number of memory allocations. In this cas, the data
-      returned by {!Swresample.convert} is invalidated by a new call to this
-      function. *)
-  val reuse_output : t -> bool -> unit
-
   (** [Swresample.convert rsp iad] resample and convert the [iad] input audio
       data to the output audio data according to the [rsp] resampler context
       format.

--- a/swresample/swresample_stubs.c
+++ b/swresample/swresample_stubs.c
@@ -7,6 +7,10 @@
 #include <caml/mlvalues.h>
 #include <caml/threads.h>
 
+#ifndef Bytes_val
+#define Bytes_val String_val
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -267,7 +271,7 @@ static void convert_to_string(swr_t *swr, int in_nb_samples,
     swr->out_vector_nb_samples = ret;
   }
 
-  memcpy(String_val(swr->out_vector), swr->out.data[0], len);
+  memcpy(Bytes_val(swr->out_vector), swr->out.data[0], len);
 }
 
 static void convert_to_planar_string(swr_t *swr, int in_nb_samples,
@@ -295,7 +299,7 @@ static void convert_to_planar_string(swr_t *swr, int in_nb_samples,
   }
 
   for (i = 0; i < swr->out.nb_channels; i++) {
-    memcpy(String_val(Field(swr->out_vector, i)), swr->out.data[i], len);
+    memcpy(Bytes_val(Field(swr->out_vector, i)), swr->out.data[i], len);
   }
 }
 

--- a/swscale/config/discover.ml
+++ b/swscale/config/discover.ml
@@ -11,7 +11,7 @@ let () =
           | Some pc -> (
               match
                 C.Pkg_config.query_expr_err pc ~package:"libswscale"
-                  ~expr:"libswscale >= 5.1.100"
+                  ~expr:"libswscale >= 4.8.100"
               with
                 | Error msg -> failwith msg
                 | Ok deps -> deps )

--- a/swscale/swscale.ml
+++ b/swscale/swscale.ml
@@ -97,6 +97,5 @@ module Make (I : VideoData) (O : VideoData) = struct
          (Avcodec.Video.get_pixel_format out_codec)
   *)
 
-  external reuse_output : t -> bool -> unit = "ocaml_swscale_reuse_output"
   external convert : t -> I.t -> O.t = "ocaml_swscale_convert"
 end

--- a/swscale/swscale.mli
+++ b/swscale/swscale.mli
@@ -61,13 +61,6 @@ module Make (I : VideoData) (O : VideoData) : sig
   (** [Swscale.from_codec_to_codec flags in_vc out_vc] do the same as {!Swresample.create} with the [in_vc] video codec properties as input format and the [out_vc] video codec properties as output format. *)
 *)
 
-  (** [Swscale.reuse_output ro] enables or disables the reuse of
-      {!Swscale.convert} output according to the value of [ro]. Reusing the
-      output reduces the number of memory allocations. In this cas, the data
-      returned by {!Swscale.convert} is invalidated by a new call to this
-      function. *)
-  val reuse_output : t -> bool -> unit
-
   (** [Swscale.convert ctx ivd] scale and convert the [ivd] input video data to
       the output video data according to the [ctx] scaler context format.
 

--- a/test/resample.ml
+++ b/test/resample.ml
@@ -47,10 +47,6 @@ let test () =
   let r9 = R9.create `Stereo 96000 `Stereo 44100 in
   let r10 = R10.create `Stereo 44100 `Mono 44100 in
 
-  R0.reuse_output r0 true;
-  R4.reuse_output r4 true;
-  R10.reuse_output r10 true;
-
   for note = 0 to 95 do
     let freq = 22.5 *. (2. ** (foi note /. 12.)) in
     let len = int_of_float (frate /. freq *. floor (freq /. 4.)) in


### PR DESCRIPTION
Remove internal conversions and implicit initialization. Expect the user to setup frames with the right data.