### PR TITLE
Export `AVOptions`!

### DIFF
--- a/av/av.ml
+++ b/av/av.ml
@@ -7,6 +7,7 @@ let () = init ()
 let _opt_val = function
   | `String s -> s
   | `Int i -> string_of_int i
+  | `Int64 i -> Int64.to_string i
   | `Float f -> string_of_float f
 
 let opts_default = function None -> Hashtbl.create 0 | Some opts -> opts
@@ -274,7 +275,7 @@ let add_audio_opts ?channels ?channel_layout ~sample_rate ~sample_format
   on_opt channels (fun channels -> Hashtbl.add opts "ac" (`Int channels));
   on_opt channel_layout (fun channel_layout ->
       Hashtbl.add opts "channel_layout"
-        (`Int (Channel_layout.get_id channel_layout)));
+        (`Int64 (Channel_layout.get_id channel_layout)));
   Hashtbl.add opts "sample_fmt"
     (`Int (Avutil.Sample_format.get_id sample_format));
   Hashtbl.add opts "time_base" (`String (Avutil.string_of_rational time_base))

--- a/avdevice/avdevice.ml
+++ b/avdevice/avdevice.ml
@@ -62,6 +62,7 @@ external open_output_format :
 let _opt_val = function
   | `String s -> s
   | `Int i -> string_of_int i
+  | `Int64 i -> Int64.to_string i
   | `Float f -> string_of_float f
 
 let mk_opts = function

--- a/avfilter/avfilter.ml
+++ b/avfilter/avfilter.ml
@@ -28,7 +28,7 @@ type ('a, 'b) pads =
 type 'a filter = {
   name : string;
   description : string;
-  options: Avutil.Options.t;
+  options : Avutil.Options.t;
   io : (('a, [ `Input ]) pads, ('a, [ `Output ]) pads) io;
 }
 
@@ -85,7 +85,7 @@ type ('a, 'b, 'c) _filter = {
   _description : string;
   _inputs : ('a, 'b, 'c) pad array;
   _outputs : ('a, 'b, 'c) pad array;
-  _options: Avutil.Options.t;
+  _options : Avutil.Options.t;
 }
 
 external register_all : unit -> unit = "ocaml_avfilter_register_all"
@@ -126,7 +126,9 @@ let filters, abuffer, buffer, abuffersink, buffersink =
         let io =
           { inputs = split_pads _inputs; outputs = split_pads _outputs }
         in
-        let filter = { name = _name; description = _description; options = _options; io } in
+        let filter =
+          { name = _name; description = _description; options = _options; io }
+        in
         match _name with
           | s when s = "abuffer" ->
               (filters, Some filter, buffer, abuffersink, buffersink)

--- a/avfilter/avfilter.ml
+++ b/avfilter/avfilter.ml
@@ -3,6 +3,7 @@
 type valued_arg =
   [ `String of string
   | `Int of int
+  | `Int64 of int64
   | `Float of float
   | `Rational of Avutil.rational ]
 
@@ -178,6 +179,8 @@ let rec args_of_args cur = function
       args_of_args (Printf.sprintf "%s=%s" lbl s :: cur) args
   | `Pair (lbl, `Int i) :: args ->
       args_of_args (Printf.sprintf "%s=%i" lbl i :: cur) args
+  | `Pair (lbl, `Int64 i) :: args ->
+      args_of_args (Printf.sprintf "%s=%Li" lbl i :: cur) args
   | `Pair (lbl, `Float f) :: args ->
       args_of_args (Printf.sprintf "%s=%f" lbl f :: cur) args
   | `Pair (lbl, `Rational { Avutil.num; den }) :: args ->
@@ -354,7 +357,7 @@ module Utils = struct
         `Pair ("time_base", `Rational in_time_base);
         `Pair
           ( "channel_layout",
-            `Int (Avutil.Channel_layout.get_id in_params.channel_layout) );
+            `Int64 (Avutil.Channel_layout.get_id in_params.channel_layout) );
         `Pair
           ( "sample_fmt",
             `Int (Avutil.Sample_format.get_id in_params.sample_format) );
@@ -378,8 +381,8 @@ module Utils = struct
                 `Pair ("in_sample_rate", `Int in_params.sample_rate);
                 `Pair
                   ( "in_channel_layout",
-                    `Int (Avutil.Channel_layout.get_id in_params.channel_layout)
-                  );
+                    `Int64
+                      (Avutil.Channel_layout.get_id in_params.channel_layout) );
                 `Pair
                   ( "in_sample_fmt",
                     `Int (Avutil.Sample_format.get_id in_params.sample_format)
@@ -387,7 +390,7 @@ module Utils = struct
                 `Pair ("out_sample_rate", `Int out_params.sample_rate);
                 `Pair
                   ( "out_channel_layout",
-                    `Int
+                    `Int64
                       (Avutil.Channel_layout.get_id out_params.channel_layout)
                   );
                 `Pair

--- a/avfilter/avfilter.ml
+++ b/avfilter/avfilter.ml
@@ -28,6 +28,7 @@ type ('a, 'b) pads =
 type 'a filter = {
   name : string;
   description : string;
+  options: Avutil.Options.t;
   io : (('a, [ `Input ]) pads, ('a, [ `Output ]) pads) io;
 }
 
@@ -84,6 +85,7 @@ type ('a, 'b, 'c) _filter = {
   _description : string;
   _inputs : ('a, 'b, 'c) pad array;
   _outputs : ('a, 'b, 'c) pad array;
+  _options: Avutil.Options.t;
 }
 
 external register_all : unit -> unit = "ocaml_avfilter_register_all"
@@ -120,11 +122,11 @@ let filters, abuffer, buffer, abuffersink, buffersink =
   let filters, abuffer, buffer, abuffersink, buffersink =
     Array.fold_left
       (fun (filters, abuffer, buffer, abuffersink, buffersink)
-           { _name; _description; _inputs; _outputs } ->
+           { _name; _description; _options; _inputs; _outputs } ->
         let io =
           { inputs = split_pads _inputs; outputs = split_pads _outputs }
         in
-        let filter = { name = _name; description = _description; io } in
+        let filter = { name = _name; description = _description; options = _options; io } in
         match _name with
           | s when s = "abuffer" ->
               (filters, Some filter, buffer, abuffersink, buffersink)

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -24,6 +24,7 @@ type ('a, 'b) pads =
 type 'a filter = {
   name : string;
   description : string;
+  options: Avutil.Options.t;
   io : (('a, [ `Input ]) pads, ('a, [ `Output ]) pads) io;
 }
 

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -5,7 +5,11 @@ open Avutil
 type config
 
 type valued_arg =
-  [ `String of string | `Int of int | `Float of float | `Rational of rational ]
+  [ `String of string
+  | `Int of int
+  | `Int64 of int64
+  | `Float of float
+  | `Rational of rational ]
 
 type args = [ `Flag of string | `Pair of string * valued_arg ]
 type ('a, 'b) av = { audio : 'a; video : 'b }

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -24,7 +24,7 @@ type ('a, 'b) pads =
 type 'a filter = {
   name : string;
   description : string;
-  options: Avutil.Options.t;
+  options : Avutil.Options.t;
   io : (('a, [ `Input ]) pads, ('a, [ `Output ]) pads) io;
 }
 

--- a/avfilter/avfilter_stubs.c
+++ b/avfilter/avfilter_stubs.c
@@ -50,7 +50,7 @@ CAMLprim value ocaml_avfilter_get_all_filters(value unit) {
   opaque = 0;
   while ((f = av_filter_iterate(&opaque))) {
 #endif
-    cur = caml_alloc_tuple(4);
+    cur = caml_alloc_tuple(5);
     Store_field(cur, 0, caml_copy_string(f->name));
     Store_field(cur, 1, caml_copy_string(f->description));
 
@@ -127,6 +127,7 @@ CAMLprim value ocaml_avfilter_get_all_filters(value unit) {
       Store_field(pads, i, pad);
     }
     Store_field(cur, 3, pads);
+    Store_field(cur, 4, (value)f->priv_class);
 
     Store_field(ret, c, cur);
     c++;

--- a/avfilter/avfilter_stubs.c
+++ b/avfilter/avfilter_stubs.c
@@ -338,8 +338,7 @@ CAMLprim value ocaml_avfilter_buffersink_get_sample_format(value _src) {
   CAMLparam0();
 
   caml_release_runtime_system();
-  int sample_format =
-    av_buffersink_get_format((AVFilterContext *)_src);
+  int sample_format = av_buffersink_get_format((AVFilterContext *)_src);
   caml_acquire_runtime_system();
 
   CAMLreturn(Val_SampleFormat((enum AVSampleFormat)sample_format));
@@ -369,8 +368,7 @@ CAMLprim value ocaml_avfilter_buffersink_get_pixel_format(value _src) {
   CAMLparam0();
 
   caml_release_runtime_system();
-  int pixel_format =
-    av_buffersink_get_format((AVFilterContext *)_src);
+  int pixel_format = av_buffersink_get_format((AVFilterContext *)_src);
   caml_acquire_runtime_system();
 
   CAMLreturn(Val_PixelFormat((enum AVPixelFormat)pixel_format));

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -280,8 +280,10 @@ module Options = struct
     | `Export
     | `Readonly
     | `Bsf_param
+    | `Runtime_param
     | `Filtering_param
-    | `Deprecated ]
+    | `Deprecated
+    | `Child_consts ]
 
   external int_of_flag : flag -> int = "ocaml_avutil_av_opt_int_of_flag"
 
@@ -299,8 +301,10 @@ module Options = struct
         `Export;
         `Readonly;
         `Bsf_param;
+        `Runtime_param;
         `Filtering_param;
         `Deprecated;
+        `Child_consts
       ]
 
   type spec =

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -341,7 +341,7 @@ module Options = struct
     = "ocaml_avutil_av_opt_next"
 
   let constant_of_opt opt (name, { _default; _ }) =
-    let append fn l = ((name, fn (Option.get _default)) :: l) in
+    let append fn l = (name, fn (Option.get _default)) :: l in
 
     let spec =
       (* See: https://ffmpeg.org/doxygen/trunk/opt_8c_source.html#l01281 *)
@@ -433,16 +433,13 @@ module Options = struct
       let spec =
         match _spec with
           | `Flags { _default; _min; _max } ->
-              `Flags
-                { default = _default; min = _min; max = _max; values = [] }
+              `Flags { default = _default; min = _min; max = _max; values = [] }
           | `Int { _default; _min; _max; _ } ->
               `Int { default = _default; min = _min; max = _max; values = [] }
           | `Int64 { _default; _min; _max; _ } ->
-              `Int64
-                { default = _default; min = _min; max = _max; values = [] }
+              `Int64 { default = _default; min = _min; max = _max; values = [] }
           | `Float { _default; _min; _max; _ } ->
-              `Float
-                { default = _default; min = _min; max = _max; values = [] }
+              `Float { default = _default; min = _min; max = _max; values = [] }
           | `Double { _default; _min; _max; _ } ->
               `Double
                 { default = _default; min = _min; max = _max; values = [] }
@@ -456,8 +453,7 @@ module Options = struct
               `Binary
                 { default = _default; min = _min; max = _max; values = [] }
           | `Dict { _default; _min; _max; _ } ->
-              `Dict
-                { default = _default; min = _min; max = _max; values = [] }
+              `Dict { default = _default; min = _min; max = _max; values = [] }
           | `UInt64 { _default; _min; _max; _ } ->
               `UInt64
                 { default = _default; min = _min; max = _max; values = [] }
@@ -477,14 +473,12 @@ module Options = struct
               `Duration
                 { default = _default; min = _min; max = _max; values = [] }
           | `Color { _default; _min; _max; _ } ->
-              `Color
-                { default = _default; min = _min; max = _max; values = [] }
+              `Color { default = _default; min = _min; max = _max; values = [] }
           | `Channel_layout { _default; _min; _max; _ } ->
               `Channel_layout
                 { default = _default; min = _min; max = _max; values = [] }
           | `Bool { _default; _min; _max; _ } ->
-              `Bool
-                { default = _default; min = _min; max = _max; values = [] }
+              `Bool { default = _default; min = _min; max = _max; values = [] }
           | `Constant _ -> assert false
       in
       let opt = { name = _name; help = _help; spec } in

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -337,8 +337,10 @@ module Options = struct
     _cursor : _cursor option;
   }
 
-  external av_opt_next : _cursor option -> t -> _opt option
+  external av_opt_next : _cursor option -> t -> int64 -> int64 -> _opt option
     = "ocaml_avutil_av_opt_next"
+
+  let av_opt_next cursor t = av_opt_next cursor t Int64.min_int Int64.max_int
 
   let constant_of_opt opt (name, { _default; _ }) =
     let append fn l = (name, fn (Option.get _default)) :: l in

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -337,10 +337,8 @@ module Options = struct
     _cursor : _cursor option;
   }
 
-  external av_opt_next : _cursor option -> t -> int64 -> int64 -> _opt option
+  external av_opt_next : _cursor option -> t -> _opt option
     = "ocaml_avutil_av_opt_next"
-
-  let av_opt_next cursor t = av_opt_next cursor t Int64.min_int Int64.max_int
 
   let constant_of_opt opt (name, { _default; _ }) =
     let append fn l = (name, fn (Option.get _default)) :: l in

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -271,8 +271,8 @@ module Options = struct
     values : (string * 'a) list;
   }
 
-  type flag = [
-    | `Encoding_param
+  type flag =
+    [ `Encoding_param
     | `Decoding_param
     | `Audio_param
     | `Video_param
@@ -281,27 +281,27 @@ module Options = struct
     | `Readonly
     | `Bsf_param
     | `Filtering_param
-    | `Deprecated
-  ]
+    | `Deprecated ]
 
   external int_of_flag : flag -> int = "ocaml_avutil_av_opt_int_of_flag"
 
   let flags_of_flags _flags =
-    List.fold_left (fun flags flag ->
-      if _flags land (int_of_flag flag) = 0 then
-        flags
-      else
-        flag :: flags) [] [
-     `Encoding_param;
-     `Decoding_param;
-     `Audio_param;
-     `Video_param;
-     `Subtitle_param;
-     `Export;
-     `Readonly;
-     `Bsf_param;
-     `Filtering_param;
-     `Deprecated]
+    List.fold_left
+      (fun flags flag ->
+        if _flags land int_of_flag flag = 0 then flags else flag :: flags)
+      []
+      [
+        `Encoding_param;
+        `Decoding_param;
+        `Audio_param;
+        `Video_param;
+        `Subtitle_param;
+        `Export;
+        `Readonly;
+        `Bsf_param;
+        `Filtering_param;
+        `Deprecated;
+      ]
 
   type spec =
     [ `Flags of int64 entry
@@ -323,7 +323,13 @@ module Options = struct
     | `Channel_layout of Channel_layout.t entry
     | `Bool of bool entry ]
 
-  type opt = { name : string; help : string option; flags : flag list; spec : spec }
+  type opt = {
+    name : string;
+    help : string option;
+    flags : flag list;
+    spec : spec;
+  }
+
   type 'a _entry = { _default : 'a option; _min : 'a option; _max : 'a option }
   type constant
 
@@ -514,7 +520,9 @@ module Options = struct
               `Bool { default = _default; min = _min; max = _max; values = [] }
           | `Constant _ -> assert false
       in
-      let opt = { name = _name; help = _help; flags = flags_of_flags _flags; spec } in
+      let opt =
+        { name = _name; help = _help; flags = flags_of_flags _flags; spec }
+      in
       match _unit with
         | Some u when Hashtbl.mem constants u ->
             List.fold_left constant_of_opt opt (Hashtbl.find_all constants u)

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -267,12 +267,12 @@ module Options : sig
   type t
 
   type 'a entry = {
-    default : 'a;
+    default : 'a option;
     (* Used only for numerical options. *)
     min : 'a option;
     max : 'a option;
-    (* Used only for constant options. *)
-    values : (string * 'a) list option;
+    (* Pre-defined options options. *)
+    values : (string * 'a) list;
   }
 
   type spec =

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -266,6 +266,19 @@ end
 module Options : sig
   type t
 
+  type flag = [
+    | `Encoding_param
+    | `Decoding_param
+    | `Audio_param
+    | `Video_param
+    | `Subtitle_param
+    | `Export
+    | `Readonly
+    | `Bsf_param
+    | `Filtering_param
+    | `Deprecated
+  ]
+
   type 'a entry = {
     default : 'a option;
     (* Used only for numerical options. *)
@@ -295,7 +308,7 @@ module Options : sig
     | `Channel_layout of Channel_layout.t entry
     | `Bool of bool entry ]
 
-  type opt = { name : string; help : string option; spec : spec }
+  type opt = { name : string; help : string option; flags : flag list; spec : spec }
 
   val opts : t -> opt list
 end

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -2,8 +2,8 @@
 
 (* {1 Options } *)
 
-type opt_val = [ `String of string | `Int of int | `Float of float ]
-type opts = (string, opt_val) Hashtbl.t
+type value = [ `String of string | `Int of int | `Float of float ]
+type opts = (string, value) Hashtbl.t
 
 (** {1 Line} *)
 
@@ -258,4 +258,42 @@ module Subtitle : sig
   (** Convert subtitle frame to lines. The two float are the start and the end
       dislpay time in seconds. *)
   val frame_to_lines : subtitle frame -> float * float * string list
+end
+
+(** {5 Options} *)
+module Options : sig
+  type t
+
+  type 'a entry = {
+    default : 'a option;
+    (* Used only for numerical options. *)
+    min : 'a option;
+    max : 'a option;
+    (* Used only for constant options. *)
+    values : (string * 'a) list option;
+  }
+
+  type spec =
+    [ `Flags of int64 entry
+    | `Int of int entry
+    | `Int64 of int64 entry
+    | `Float of float entry
+    | `Double of float entry
+    | `String of string entry
+    | `Rational of rational entry
+    | `Binary of string entry
+    | `Dict of (string, string) Hashtbl.t entry
+    | `UInt64 of int64 entry
+    | `Image_size of (int * int) entry
+    | `Pixel_fmt of Pixel_format.t entry
+    | `Sample_fmt of Sample_format.t entry
+    | `Video_rate of rational entry
+    | `Duration of int64 entry
+    | `Color of string entry
+    | `Channel_layout of Channel_layout.t entry
+    | `Bool of bool entry ]
+
+  type opt = { name : string; help : string option; spec : spec }
+
+  val opts : t -> opt list
 end

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -2,7 +2,9 @@
 
 (* {1 Options } *)
 
-type value = [ `String of string | `Int of int | `Float of float ]
+type value =
+  [ `String of string | `Int of int | `Int64 of int64 | `Float of float ]
+
 type opts = (string, value) Hashtbl.t
 
 (** {1 Line} *)
@@ -137,7 +139,7 @@ module Channel_layout : sig
 
   (** Return the internal ID for a channel layout. This number should be passed
       as the "channel_layout" [opts] in [Av.new_audio_stream] .*)
-  val get_id : t -> int
+  val get_id : t -> int64
 end
 
 (** Formats for audio samples. *)
@@ -265,7 +267,7 @@ module Options : sig
   type t
 
   type 'a entry = {
-    default : 'a option;
+    default : 'a;
     (* Used only for numerical options. *)
     min : 'a option;
     max : 'a option;
@@ -282,12 +284,12 @@ module Options : sig
     | `String of string entry
     | `Rational of rational entry
     | `Binary of string entry
-    | `Dict of (string, string) Hashtbl.t entry
+    | `Dict of string entry
     | `UInt64 of int64 entry
-    | `Image_size of (int * int) entry
+    | `Image_size of string entry
     | `Pixel_fmt of Pixel_format.t entry
     | `Sample_fmt of Sample_format.t entry
-    | `Video_rate of rational entry
+    | `Video_rate of string entry
     | `Duration of int64 entry
     | `Color of string entry
     | `Channel_layout of Channel_layout.t entry

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -266,8 +266,8 @@ end
 module Options : sig
   type t
 
-  type flag = [
-    | `Encoding_param
+  type flag =
+    [ `Encoding_param
     | `Decoding_param
     | `Audio_param
     | `Video_param
@@ -276,8 +276,7 @@ module Options : sig
     | `Readonly
     | `Bsf_param
     | `Filtering_param
-    | `Deprecated
-  ]
+    | `Deprecated ]
 
   type 'a entry = {
     default : 'a option;
@@ -308,7 +307,12 @@ module Options : sig
     | `Channel_layout of Channel_layout.t entry
     | `Bool of bool entry ]
 
-  type opt = { name : string; help : string option; flags : flag list; spec : spec }
+  type opt = {
+    name : string;
+    help : string option;
+    flags : flag list;
+    spec : spec;
+  }
 
   val opts : t -> opt list
 end

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -275,8 +275,10 @@ module Options : sig
     | `Export
     | `Readonly
     | `Bsf_param
+    | `Runtime_param
     | `Filtering_param
-    | `Deprecated ]
+    | `Deprecated
+    | `Child_consts ]
 
   type 'a entry = {
     default : 'a option;

--- a/avutil/avutil.mli
+++ b/avutil/avutil.mli
@@ -271,7 +271,7 @@ module Options : sig
     (* Used only for numerical options. *)
     min : 'a option;
     max : 'a option;
-    (* Pre-defined options options. *)
+    (* Pre-defined options. *)
     values : (string * 'a) list;
   }
 

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -1045,9 +1045,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
     _type = PVV_Duration;
 
   int64_opt:
-    if (_opt_cursor->default_val.i64 == INT64_MIN)
+    if (_opt_cursor->default_val.i64 <= INT64_MIN)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
-    else if (_opt_cursor->default_val.i64 == INT64_MAX)
+    else if (_opt_cursor->default_val.i64 >= INT64_MAX)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
@@ -1055,9 +1055,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
 
     _tmp = caml_alloc_small(1, 0);
 
-    if (_opt_cursor->min == INT64_MIN)
+    if (_opt_cursor->min <= INT64_MIN)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
-    else if (_opt_cursor->min == INT64_MAX)
+    else if (_opt_cursor->min >= INT64_MAX)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->min));
@@ -1066,9 +1066,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
 
     _tmp = caml_alloc_small(1, 0);
 
-    if (_opt_cursor->max == INT64_MIN)
+    if (_opt_cursor->max <= INT64_MIN)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
-    else if (_opt_cursor->max == INT64_MAX)
+    else if (_opt_cursor->max >= INT64_MAX)
       Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->max));

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -961,9 +961,6 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
     } while (_opt_cursor == NULL);
   }
 
-  if (_opt_cursor == NULL)
-    CAMLreturn(Val_none);
-
   _opt = caml_alloc_tuple(6);
   Store_field(_opt, 0, caml_copy_string(_opt_cursor->name));
 

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -981,7 +981,6 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
   Store_field(_spec, 0, Val_none);
   Store_field(_spec, 1, Val_none);
   Store_field(_spec, 2, Val_none);
-  Store_field(_opt, 2, _spec);
 
   switch (_opt_cursor->type) {
   case AV_OPT_TYPE_CONST:
@@ -1142,19 +1141,21 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
   Store_field(_tmp, 1, _spec);
   Store_field(_opt, 2, _tmp);
 
+  Store_field(_opt, 3, Val_int(_opt_cursor->flags));
+
   if (_opt_cursor->unit == NULL || strlen(_opt_cursor->unit) == 0)
-    Store_field(_opt, 3, Val_none);
+    Store_field(_opt, 4, Val_none);
   else {
     _tmp = caml_alloc_small(1, 0);
     Store_field(_tmp, 0, caml_copy_string(_opt_cursor->unit));
-    Store_field(_opt, 3, _tmp);
+    Store_field(_opt, 4, _tmp);
   }
 
   _tmp = caml_alloc_small(1, 0);
   Store_field(_tmp, 0, caml_alloc_tuple(2));
   Store_field(Field(_tmp, 0), 0, (value)_opt_cursor);
   Store_field(Field(_tmp, 0), 1, (value)_class_cursor);
-  Store_field(_opt, 4, _tmp);
+  Store_field(_opt, 5, _tmp);
 
   _tmp = caml_alloc_small(1, 0);
   Store_field(_tmp, 0, _opt);
@@ -1175,4 +1176,33 @@ CAMLprim value ocaml_avutil_avopt_default_double(value _opt) {
 CAMLprim value ocaml_avutil_avopt_default_string(value _opt) {
   CAMLparam0();
   CAMLreturn(caml_copy_string(((const AVOption *)_opt)->default_val.str));
+}
+
+CAMLprim value ocaml_avutil_av_opt_int_of_flag(value _flag) {
+  CAMLparam0();
+
+  switch (_flag) {
+  case PVV_Encoding_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_ENCODING_PARAM));
+  case PVV_Decoding_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_DECODING_PARAM));
+  case PVV_Audio_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_AUDIO_PARAM));
+  case PVV_Video_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_VIDEO_PARAM));
+  case PVV_Subtitle_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_SUBTITLE_PARAM));
+  case PVV_Export:
+    CAMLreturn(Val_int(AV_OPT_FLAG_EXPORT));
+  case PVV_Readonly:
+    CAMLreturn(Val_int(AV_OPT_FLAG_READONLY));
+  case PVV_Bsf_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_BSF_PARAM));
+  case PVV_Filtering_param:
+    CAMLreturn(Val_int(AV_OPT_FLAG_FILTERING_PARAM));
+  case PVV_Deprecated:
+    CAMLreturn(Val_int(AV_OPT_FLAG_DEPRECATED));
+  default:
+    caml_failwith("Invalid option flag!");
+  }
 }

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -929,8 +929,8 @@ CAMLprim value ocaml_avutil_subtitle_to_lines(value _subtitle) {
   CAMLreturn(ans);
 }
 
-CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
-  CAMLparam2(_cursor, _class);
+CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class, value _int64_min, value _int64_max) {
+  CAMLparam4(_cursor, _class, _int64_min, _int64_max);
   CAMLlocal4(_opt, _type, _tmp, _spec);
 
   const AVClass *_class_cursor;
@@ -1045,15 +1045,34 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
     _type = PVV_Duration;
 
   int64_opt:
-    Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
+    if (_opt_cursor->default_val.i64 == INT64_MIN)
+      Store_field(_tmp, 0, _int64_min);
+    else if (_opt_cursor->default_val.i64 == INT64_MAX)
+      Store_field(_tmp, 0, _int64_max);
+    else
+      Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
     Store_field(_spec, 0, _tmp);
 
     _tmp = caml_alloc_small(1, 0);
-    Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->min));
+
+    if (_opt_cursor->min == INT64_MIN)
+      Store_field(_tmp, 0, _int64_min);
+    else if (_opt_cursor->min == INT64_MAX)
+      Store_field(_tmp, 0, _int64_max);
+    else
+      Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->min));
+
     Store_field(_spec, 1, _tmp);
 
     _tmp = caml_alloc_small(1, 0);
-    Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->max));
+
+    if (_opt_cursor->max == INT64_MIN)
+      Store_field(_tmp, 0, _int64_min);
+    else if (_opt_cursor->max == INT64_MAX)
+      Store_field(_tmp, 0, _int64_max);
+    else
+      Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->max));
+
     Store_field(_spec, 2, _tmp);
     break;
 

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -1197,7 +1197,11 @@ CAMLprim value ocaml_avutil_av_opt_int_of_flag(value _flag) {
   case PVV_Readonly:
     CAMLreturn(Val_int(AV_OPT_FLAG_READONLY));
   case PVV_Bsf_param:
+#ifdef AV_OPT_FLAG_BSF_PARAM
     CAMLreturn(Val_int(AV_OPT_FLAG_BSF_PARAM));
+#else
+    CAMLreturn(Val_int(0));
+#endif
   case PVV_Filtering_param:
     CAMLreturn(Val_int(AV_OPT_FLAG_FILTERING_PARAM));
   case PVV_Deprecated:

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -929,8 +929,8 @@ CAMLprim value ocaml_avutil_subtitle_to_lines(value _subtitle) {
   CAMLreturn(ans);
 }
 
-CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class, value _int64_min, value _int64_max) {
-  CAMLparam4(_cursor, _class, _int64_min, _int64_max);
+CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
+  CAMLparam2(_cursor, _class);
   CAMLlocal4(_opt, _type, _tmp, _spec);
 
   const AVClass *_class_cursor;
@@ -1046,9 +1046,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class, value _int6
 
   int64_opt:
     if (_opt_cursor->default_val.i64 == INT64_MIN)
-      Store_field(_tmp, 0, _int64_min);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
     else if (_opt_cursor->default_val.i64 == INT64_MAX)
-      Store_field(_tmp, 0, _int64_max);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
     Store_field(_spec, 0, _tmp);
@@ -1056,9 +1056,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class, value _int6
     _tmp = caml_alloc_small(1, 0);
 
     if (_opt_cursor->min == INT64_MIN)
-      Store_field(_tmp, 0, _int64_min);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
     else if (_opt_cursor->min == INT64_MAX)
-      Store_field(_tmp, 0, _int64_max);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->min));
 
@@ -1067,9 +1067,9 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class, value _int6
     _tmp = caml_alloc_small(1, 0);
 
     if (_opt_cursor->max == INT64_MIN)
-      Store_field(_tmp, 0, _int64_min);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
     else if (_opt_cursor->max == INT64_MAX)
-      Store_field(_tmp, 0, _int64_max);
+      Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
     else
       Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->max));
 

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -1201,7 +1201,23 @@ CAMLprim value ocaml_avutil_av_opt_int_of_flag(value _flag) {
   case PVV_Filtering_param:
     CAMLreturn(Val_int(AV_OPT_FLAG_FILTERING_PARAM));
   case PVV_Deprecated:
+#ifdef AV_OPT_FLAG_DEPRECATED
     CAMLreturn(Val_int(AV_OPT_FLAG_DEPRECATED));
+#else
+    CAMLreturn(Val_int(0));
+#endif
+  case PVV_Child_consts:
+#ifdef AV_OPT_FLAG_AV_OPT_FLAG_CHILD_CONSTS
+    CAMLreturn(Val_int(AV_OPT_FLAG_CHILD_CONSTS));
+#else
+    CAMLreturn(Val_int(0));
+#endif
+  case PVV_Runtime_param:
+#ifdef AV_OPT_FLAG_RUNTIME_PARAM
+    CAMLreturn(Val_int(AV_OPT_FLAG_RUNTIME_PARAM));
+#else
+    CAMLreturn(Val_int(0));
+#endif
   default:
     caml_failwith("Invalid option flag!");
   }

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -945,7 +945,8 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
     _class_cursor = (const AVClass *)Field(Some_val(_cursor), 1);
   }
 
-  if (_class_cursor == NULL) CAMLreturn(Val_none);
+  if (_class_cursor == NULL)
+    CAMLreturn(Val_none);
 
   _opt_cursor = av_opt_next(&_class_cursor, _opt_cursor);
 
@@ -954,7 +955,8 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
       _class_cursor =
           av_opt_child_class_next((const AVClass *)_class, _class_cursor);
 
-      if (_class_cursor == NULL) CAMLreturn(Val_none);
+      if (_class_cursor == NULL)
+        CAMLreturn(Val_none);
 
       _opt_cursor = av_opt_next(&_class_cursor, _opt_cursor);
     } while (_opt_cursor == NULL);
@@ -1148,15 +1150,15 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
 
 CAMLprim value ocaml_avutil_avopt_default_int64(value _opt) {
   CAMLparam0();
-  CAMLreturn(caml_copy_int64(((const AVOption*)_opt)->default_val.i64));
+  CAMLreturn(caml_copy_int64(((const AVOption *)_opt)->default_val.i64));
 }
 
 CAMLprim value ocaml_avutil_avopt_default_double(value _opt) {
   CAMLparam0();
-  CAMLreturn(caml_copy_double(((const AVOption*)_opt)->default_val.dbl));
+  CAMLreturn(caml_copy_double(((const AVOption *)_opt)->default_val.dbl));
 }
 
 CAMLprim value ocaml_avutil_avopt_default_string(value _opt) {
   CAMLparam0();
-  CAMLreturn(caml_copy_string(((const AVOption*)_opt)->default_val.str));
+  CAMLreturn(caml_copy_string(((const AVOption *)_opt)->default_val.str));
 }

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -237,7 +237,6 @@ value ocaml_avutil_av_d2q(value f) {
   CAMLlocal1(ret);
 
   const AVRational r = av_d2q(Double_val(f), INT_MAX);
-  ;
   value_of_rational(&r, &ret);
 
   CAMLreturn(ret);

--- a/avutil/avutil_stubs.c
+++ b/avutil/avutil_stubs.c
@@ -1045,12 +1045,7 @@ CAMLprim value ocaml_avutil_av_opt_next(value _cursor, value _class) {
     _type = PVV_Duration;
 
   int64_opt:
-    if (_opt_cursor->default_val.i64 <= INT64_MIN)
-      Store_field(_tmp, 0, caml_copy_int64(INT64_MIN));
-    else if (_opt_cursor->default_val.i64 >= INT64_MAX)
-      Store_field(_tmp, 0, caml_copy_int64(INT64_MAX));
-    else
-      Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
+    Store_field(_tmp, 0, caml_copy_int64(_opt_cursor->default_val.i64));
     Store_field(_spec, 0, _tmp);
 
     _tmp = caml_alloc_small(1, 0);

--- a/examples/aresample.ml
+++ b/examples/aresample.ml
@@ -52,7 +52,7 @@ let () =
           `Pair ("sample_rate", `Int sample_rate);
           `Pair ("sample_fmt", `Int sample_format);
           `Pair ("channels", `Int channels);
-          `Pair ("channel_layout", `Int channel_layout);
+          `Pair ("channel_layout", `Int64 channel_layout);
         ]
       in
       {

--- a/examples/list_filters.ml
+++ b/examples/list_filters.ml
@@ -34,16 +34,18 @@ let string_of_spec to_string { Avutil.Options.default; min; max; values } =
 
 let string_of_flags flags =
   let string_of_flag = function
-    | `Encoding_param -> "Encoding_param"
-    | `Decoding_param -> "Decoding_param"
-    | `Audio_param -> "Audio_param"
-    | `Video_param -> "Video_param"
-    | `Subtitle_param -> "Subtitle_param"
-    | `Export -> "Export"
-    | `Readonly -> "Readonly"
-    | `Bsf_param -> "Bsf_param"
-    | `Filtering_param -> "Filtering_param"
-    | `Deprecated -> "Deprecated"
+    | `Encoding_param -> "encoding param"
+    | `Decoding_param -> "decoding param"
+    | `Audio_param -> "audio param"
+    | `Video_param -> "video param"
+    | `Subtitle_param -> "subtitle param"
+    | `Export -> "export"
+    | `Readonly -> "readonly"
+    | `Bsf_param -> "bsf param"
+    | `Runtime_param -> "runtime param"
+    | `Filtering_param -> "filtering param"
+    | `Deprecated -> "deprecated"
+    | `Child_consts -> "child constants"
   in
   String.concat ", " (List.map string_of_flag flags)
 

--- a/examples/list_filters.ml
+++ b/examples/list_filters.ml
@@ -78,10 +78,10 @@ let string_of_option { Avutil.Options.name; help; flags; spec } =
       | `Bool entry -> ("bool", string_of_spec string_of_bool entry)
   in
 
-  Printf.sprintf "- %s:\n    type: %s\n    help: %s\n    flags: %s\n    spec: %s" name _type
+  Printf.sprintf
+    "- %s:\n    type: %s\n    help: %s\n    flags: %s\n    spec: %s" name _type
     (match help with None -> "none" | Some v -> v)
-    (string_of_flags flags)
-    spec
+    (string_of_flags flags) spec
 
 let () =
   let print_filters cat =

--- a/examples/list_filters.ml
+++ b/examples/list_filters.ml
@@ -32,7 +32,22 @@ let string_of_spec to_string { Avutil.Options.default; min; max; values } =
              (fun (name, v) -> Printf.sprintf "%s: %s" name (to_string v))
              values)))
 
-let string_of_option { Avutil.Options.name; help; spec } =
+let string_of_flags flags =
+  let string_of_flag = function
+    | `Encoding_param -> "Encoding_param"
+    | `Decoding_param -> "Decoding_param"
+    | `Audio_param -> "Audio_param"
+    | `Video_param -> "Video_param"
+    | `Subtitle_param -> "Subtitle_param"
+    | `Export -> "Export"
+    | `Readonly -> "Readonly"
+    | `Bsf_param -> "Bsf_param"
+    | `Filtering_param -> "Filtering_param"
+    | `Deprecated -> "Deprecated"
+  in
+  String.concat ", " (List.map string_of_flag flags)
+
+let string_of_option { Avutil.Options.name; help; flags; spec } =
   let _type, spec =
     match spec with
       | `Flags entry -> ("flags", string_of_spec Int64.to_string entry)
@@ -63,8 +78,9 @@ let string_of_option { Avutil.Options.name; help; spec } =
       | `Bool entry -> ("bool", string_of_spec string_of_bool entry)
   in
 
-  Printf.sprintf "name: %s, type: %s, help: %s, spec: %s" name _type
+  Printf.sprintf "- %s:\n    type: %s\n    help: %s\n    flags: %s\n    spec: %s" name _type
     (match help with None -> "none" | Some v -> v)
+    (string_of_flags flags)
     spec
 
 let () =
@@ -76,11 +92,11 @@ let () =
           "%s name: %s\n\
            description: %s\n\
            options:\n\
-          \  %s\n\
+           %s\n\
            inputs:%s\n\
            outputs:%s\n\n"
           cat name description
-          (String.concat "\n  " (List.map string_of_option options))
+          (String.concat "\n" (List.map string_of_option options))
           (string_of_pad inputs) (string_of_pad outputs))
   in
 

--- a/examples/list_filters.ml
+++ b/examples/list_filters.ml
@@ -22,42 +22,49 @@ let string_of_pad { audio; video } =
 
   String.concat "" (audio @ video)
 
-let string_of_spec to_string {Avutil.Options.default; min; max; values} =
-  let opt_str = function
-    | None -> "none"
-    | Some v -> to_string v
-  in
-  Printf.sprintf "{default: %s, min: %s, max: %s, values: %s}"
-    (opt_str default) (opt_str min) (opt_str max)
-      (Printf.sprintf "[%s]"
-         (String.concat ", " (List.map (fun (name, v) ->
-            Printf.sprintf "%s: %s" name (to_string v)) values)))
+let string_of_spec to_string { Avutil.Options.default; min; max; values } =
+  let opt_str = function None -> "none" | Some v -> to_string v in
+  Printf.sprintf "{default: %s, min: %s, max: %s, values: %s}" (opt_str default)
+    (opt_str min) (opt_str max)
+    (Printf.sprintf "[%s]"
+       (String.concat ", "
+          (List.map
+             (fun (name, v) -> Printf.sprintf "%s: %s" name (to_string v))
+             values)))
 
 let string_of_option { Avutil.Options.name; help; spec } =
-  let _type, spec = 
+  let _type, spec =
     match spec with
-    | `Flags entry -> "flags", string_of_spec Int64.to_string entry
-    | `Int entry -> "int", string_of_spec string_of_int entry
-    | `Int64 entry -> "int64", string_of_spec Int64.to_string entry
-    | `Float entry -> "float", string_of_spec string_of_float entry
-    | `Double entry -> "double", string_of_spec string_of_float entry
-    | `String entry -> "string", string_of_spec (fun v -> v) entry
-    | `Rational entry -> "rational", string_of_spec (fun {Avutil.num;den} -> Printf.sprintf "%d/%d" num den) entry
-    | `Binary entry -> "binary", string_of_spec (fun v -> v) entry
-    | `Dict entry -> "dict", string_of_spec (fun v -> v) entry
-    | `UInt64 entry -> "uint64", string_of_spec Int64.to_string entry
-    | `Image_size entry -> "image_size", string_of_spec (fun v -> v) entry
-    | `Pixel_fmt entry -> "pixel_fmt", string_of_spec Avutil.Pixel_format.to_string entry
-    | `Sample_fmt entry -> "sample_fmt", string_of_spec Avutil.Sample_format.get_name entry
-    | `Video_rate entry -> "video_rate", string_of_spec (fun v -> v) entry
-    | `Duration entry -> "duration", string_of_spec Int64.to_string entry
-    | `Color entry -> "color", string_of_spec (fun v -> v) entry
-    | `Channel_layout entry -> "channel_layout", string_of_spec Avutil.Channel_layout.get_description entry
-    | `Bool entry -> "bool", string_of_spec string_of_bool entry
+      | `Flags entry -> ("flags", string_of_spec Int64.to_string entry)
+      | `Int entry -> ("int", string_of_spec string_of_int entry)
+      | `Int64 entry -> ("int64", string_of_spec Int64.to_string entry)
+      | `Float entry -> ("float", string_of_spec string_of_float entry)
+      | `Double entry -> ("double", string_of_spec string_of_float entry)
+      | `String entry -> ("string", string_of_spec (fun v -> v) entry)
+      | `Rational entry ->
+          ( "rational",
+            string_of_spec
+              (fun { Avutil.num; den } -> Printf.sprintf "%d/%d" num den)
+              entry )
+      | `Binary entry -> ("binary", string_of_spec (fun v -> v) entry)
+      | `Dict entry -> ("dict", string_of_spec (fun v -> v) entry)
+      | `UInt64 entry -> ("uint64", string_of_spec Int64.to_string entry)
+      | `Image_size entry -> ("image_size", string_of_spec (fun v -> v) entry)
+      | `Pixel_fmt entry ->
+          ("pixel_fmt", string_of_spec Avutil.Pixel_format.to_string entry)
+      | `Sample_fmt entry ->
+          ("sample_fmt", string_of_spec Avutil.Sample_format.get_name entry)
+      | `Video_rate entry -> ("video_rate", string_of_spec (fun v -> v) entry)
+      | `Duration entry -> ("duration", string_of_spec Int64.to_string entry)
+      | `Color entry -> ("color", string_of_spec (fun v -> v) entry)
+      | `Channel_layout entry ->
+          ( "channel_layout",
+            string_of_spec Avutil.Channel_layout.get_description entry )
+      | `Bool entry -> ("bool", string_of_spec string_of_bool entry)
   in
 
-  Printf.sprintf "name: %s, type: %s, help: %s, spec: %s"
-    name _type (match help with None -> "none" | Some v -> v)
+  Printf.sprintf "name: %s, type: %s, help: %s, spec: %s" name _type
+    (match help with None -> "none" | Some v -> v)
     spec
 
 let () =
@@ -65,8 +72,16 @@ let () =
     List.iter (fun { name; description; options; io } ->
         let { inputs; outputs } = io in
         let options = Avutil.Options.opts options in
-        Printf.printf "%s name: %s\ndescription: %s\noptions:\n  %s\ninputs:%s\noutputs:%s\n\n"
-          cat name description (String.concat "\n  " (List.map string_of_option options)) (string_of_pad inputs) (string_of_pad outputs))
+        Printf.printf
+          "%s name: %s\n\
+           description: %s\n\
+           options:\n\
+          \  %s\n\
+           inputs:%s\n\
+           outputs:%s\n\n"
+          cat name description
+          (String.concat "\n  " (List.map string_of_option options))
+          (string_of_pad inputs) (string_of_pad outputs))
   in
 
   Printf.printf "## Buffers (inputs) ##\n\n";

--- a/gen_code/gen_code.ml
+++ b/gen_code/gen_code.ml
@@ -199,6 +199,16 @@ let gen_polymorphic_variant_h () =
       "Color";
       "Channel_layout";
       "Bool";
+      "Encoding_param";
+      "Decoding_param";
+      "Audio_param";
+      "Video_param";
+      "Subtitle_param";
+      "Export";
+      "Readonly";
+      "Bsf_param";
+      "Filtering_param";
+      "Deprecated";
       (* Errors *)
       "Bsf_not_found";
       "Decoder_not_found";

--- a/gen_code/gen_code.ml
+++ b/gen_code/gen_code.ml
@@ -179,6 +179,26 @@ let gen_polymorphic_variant_h () =
       "Buffer";
       "Link";
       "Sink";
+      (* Options *)
+      "Constant";
+      "Flags";
+      "Int";
+      "Int64";
+      "Float";
+      "Double";
+      "String";
+      "Rational";
+      "Binary";
+      "Dict";
+      "UInt64";
+      "Image_size";
+      "Pixel_fmt";
+      "Sample_fmt";
+      "Video_rate";
+      "Duration";
+      "Color";
+      "Channel_layout";
+      "Bool";
       (* Errors *)
       "Bsf_not_found";
       "Decoder_not_found";

--- a/gen_code/gen_code.ml
+++ b/gen_code/gen_code.ml
@@ -207,8 +207,10 @@ let gen_polymorphic_variant_h () =
       "Export";
       "Readonly";
       "Bsf_param";
+      "Runtime_param";
       "Filtering_param";
       "Deprecated";
+      "Child_consts";
       (* Errors *)
       "Bsf_not_found";
       "Decoder_not_found";


### PR DESCRIPTION
```
Filter name: trim
description: Pick one continuous section from the input, drop the rest.
options:
- end_frame:
    type: int64
    help: Number of the first frame that should be dropped again
    flags: filtering param, video param
    spec: {default: 9223372036854775807, min: 0, max: 9223372036854775807, values: []}
- start_frame:
    type: int64
    help: Number of the first frame that should be passed to the output
    flags: filtering param, video param
    spec: {default: -1, min: -1, max: 9223372036854775807, values: []}
- durationi:
    type: duration
    help: Maximum duration of the output
    flags: filtering param, video param
    spec: {default: 0, min: 0, max: 9223372036854775807, values: []}
- duration:
    type: duration
    help: Maximum duration of the output
    flags: filtering param, video param
    spec: {default: 0, min: 0, max: 9223372036854775807, values: []}
- end_pts:
    type: int64
    help: Timestamp of the first frame that should be dropped again
    flags: filtering param, video param
    spec: {default: -9223372036854775808, min: -9223372036854775808, max: 9223372036854775807, values: []}
- start_pts:
    type: int64
    help: Timestamp of the first frame that should be  passed
    flags: filtering param, video param
    spec: {default: -9223372036854775808, min: -9223372036854775808, max: 9223372036854775807, values: []}
- endi:
    type: duration
    help: Timestamp of the first frame that should be dropped again
    flags: filtering param, video param
    spec: {default: 9223372036854775807, min: -9223372036854775808, max: 9223372036854775807, values: []}
- end:
    type: duration
    help: Timestamp of the first frame that should be dropped again
    flags: filtering param, video param
    spec: {default: 9223372036854775807, min: -9223372036854775808, max: 9223372036854775807, values: []}
- starti:
    type: duration
    help: Timestamp of the first frame that should be passed
    flags: filtering param, video param
    spec: {default: 9223372036854775807, min: -9223372036854775808, max: 9223372036854775807, values: []}
- start:
    type: duration
    help: Timestamp of the first frame that should be passed
    flags: filtering param, video param
    spec: {default: 9223372036854775807, min: -9223372036854775808, max: 9223372036854775807, values: []}
inputs:
- name: default, type: video
outputs:
- name: default, type: video
```