### PR TITLE
add x-maintenance-intent for ffmpeg.opam

### DIFF
--- a/ffmpeg.opam
+++ b/ffmpeg.opam
@@ -34,3 +34,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+x-maintenance-intent: ["(latest)"]

--- a/ffmpeg.opam.template
+++ b/ffmpeg.opam.template
@@ -1,0 +1,1 @@
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
I figured all the other packages in this repository have the x-maintenance-intent, while the core 'ffmpeg.opam' does not.