### PR TITLE
av: add per-stream decoder configuration callbacks to open_input

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,12 @@
 ======
 * TODO: rename ffmpeg-av into ffmpeg-avformat
 * Add version API
+* Add `configure_audio_stream`, `configure_video_stream` and
+  `configure_subtitle_stream` callbacks to `Av.open_input`. These are
+  called per stream before `avformat_find_stream_info`, allowing a
+  preferred decoder and per-stream options to be set for both probing
+  and decoding.
+* Remove `Av.set_decoder` (superseded by the configure callbacks above).
 
 1.3.0 (2026-04-10)
 =====

--- a/av/av.ml
+++ b/av/av.ml
@@ -8,8 +8,7 @@ external avformat_version : unit -> int = "ocaml_avformat_version" [@@noalloc]
 
 let avformat_version =
   let v = avformat_version () in
-  Avutil.
-    { major = v lsr 16; minor = (v lsr 8) land 0xff; micro = v land 0xff }
+  Avutil.{ major = v lsr 16; minor = (v lsr 8) land 0xff; micro = v land 0xff }
 
 external container_options : unit -> Options.t = "ocaml_av_container_options"
 
@@ -55,17 +54,42 @@ end
 
 external ocaml_av_cleanup_av : _ container -> unit = "ocaml_av_cleanup_av"
 
+type 'media stream_config = {
+  codec : ('media, Avcodec.decode) Avcodec.codec option;
+  opts : opts option;
+}
+
 (* Input *)
 external open_input :
   string ->
   (input, _) format option ->
   (unit -> bool) option ->
   (string * string) array ->
-  input container * string array = "ocaml_av_open_input"
+  (audio Avcodec.params ->
+  (audio, Avcodec.decode) Avcodec.codec option * (string * string) array)
+  option ->
+  (video Avcodec.params ->
+  (video, Avcodec.decode) Avcodec.codec option * (string * string) array)
+  option ->
+  (subtitle Avcodec.params ->
+  (subtitle, Avcodec.decode) Avcodec.codec option * (string * string) array)
+  option ->
+  input container * string array
+  = "ocaml_av_open_input_bytecode" "ocaml_av_open_input"
 
-let open_input ?interrupt ?format ?opts url =
+let wrap_configure_stream fn params =
+  match fn params with
+    | { codec; opts } -> (codec, mk_opts_array (opts_default opts))
+
+let open_input ?interrupt ?format ?opts ?configure_audio_stream
+    ?configure_video_stream ?configure_subtitle_stream url =
   let opts = opts_default opts in
-  let ret, unused = open_input url format interrupt (mk_opts_array opts) in
+  let ret, unused =
+    open_input url format interrupt (mk_opts_array opts)
+      (Option.map wrap_configure_stream configure_audio_stream)
+      (Option.map wrap_configure_stream configure_video_stream)
+      (Option.map wrap_configure_stream configure_subtitle_stream)
+  in
   Gc.finalise ocaml_av_cleanup_av ret;
   filter_opts unused opts;
   ret
@@ -139,15 +163,10 @@ external input_obj : input container -> 'a = "ocaml_av_input_obj"
 let input_obj c = Obj.magic (input_obj c, c)
 
 (* Input Stream *)
-type ('a, 'b, 'c) stream = {
-  container : 'a container;
-  index : int;
-  mutable decoder : ('b, Avcodec.decode) Avcodec.codec option;
-}
-
+type ('a, 'b, 'c) stream = { container : 'a container; index : int }
 type media_type = MT_audio | MT_video | MT_data | MT_subtitle
 
-let mk_stream container index = { container; index; decoder = None }
+let mk_stream container index = { container; index }
 
 external get_codec_params : (_, 'm, _) stream -> 'm Avcodec.params
   = "ocaml_av_get_stream_codec_parameters"
@@ -188,7 +207,6 @@ let get_audio_streams container = get_streams container MT_audio
 let get_video_streams container = get_streams container MT_video
 let get_subtitle_streams container = get_streams container MT_subtitle
 let get_data_streams container = get_streams container MT_data
-let set_decoder s decoder = s.decoder <- Some decoder
 
 external _find_best_stream : input container -> media_type -> int
   = "ocaml_av_find_best_stream"
@@ -226,21 +244,21 @@ type input_result = [ packet_result | frame_result ]
 external read_input :
   (packet_result -> unit) option ->
   (int * Avutil.media_type) array ->
-  (int * ('a, Avcodec.decode) Avcodec.codec option) array ->
+  int array ->
   input container ->
   input_result = "ocaml_av_read_input"
 
 let _get_packet media_type input =
-  List.map (fun { index; container; _ } ->
+  List.map (fun { index; container } ->
       if container != input then
         raise (Failure "Inconsistent stream and input!");
       (index, media_type))
 
 let _get_frame input =
-  List.map (fun { index; container; decoder } ->
+  List.map (fun { index; container } ->
       if container != input then
         raise (Failure "Inconsistent stream and input!");
-      (index, Obj.magic decoder))
+      index)
 
 let read_input ?on_unhandled_packet ?(audio_packet = []) ?(audio_frame = [])
     ?(video_packet = []) ?(video_frame = []) ?(subtitle_packet = [])

--- a/av/av.mli
+++ b/av/av.mli
@@ -46,13 +46,26 @@ end
 
 (** {5 Input} *)
 
+type 'media stream_config = {
+  codec : ('media, Avcodec.decode) Avcodec.codec option;
+  opts : opts option;
+}
+
 (** [Av.open_input url] open the input [url] (a file name or http URL). After
     returning, if [opts] was passed, unused options are left in the hash table.
-    Raise Error if the opening failed. *)
+    The optional [configure_audio_stream], [configure_video_stream] and
+    [configure_subtitle_stream] callbacks are called once per stream of their
+    respective type after the container is opened. The returned [codec], if any,
+    is used as the decoder for that stream; [opts] are passed as per-stream
+    options to [avformat_find_stream_info]. Raise Error if the opening failed.
+*)
 val open_input :
   ?interrupt:(unit -> bool) ->
   ?format:(input, _) format ->
   ?opts:opts ->
+  ?configure_audio_stream:(audio Avcodec.params -> audio stream_config) ->
+  ?configure_video_stream:(video Avcodec.params -> video stream_config) ->
+  ?configure_subtitle_stream:(subtitle Avcodec.params -> subtitle stream_config) ->
   string ->
   input container
 
@@ -163,14 +176,11 @@ val get_frame_size : (output, audio, _) stream -> int
 val get_pixel_aspect : (_, video, _) stream -> Avutil.rational option
 
 (** Same as {!Av.get_input_duration} for the input streams. *)
-val get_duration : ?format:Time_format.t -> (input, _, _) stream -> Int64.t option
+val get_duration :
+  ?format:Time_format.t -> (input, _, _) stream -> Int64.t option
 
 (** Same as {!Av.get_input_metadata} for the input streams. *)
 val get_metadata : (input, _, _) stream -> (string * string) list
-
-(** For the use of a specific decoder for the given input stream. *)
-val set_decoder :
-  (input, 'a, _) stream -> ('a, Avcodec.decode) Avcodec.codec -> unit
 
 type packet_result =
   [ `Audio_packet of int * audio Avcodec.Packet.t

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -869,12 +869,29 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
     }
   }
 
-  if (!audio_conflict)
+  if (audio_codec_override) {
+    if (audio_conflict)
+      av_log(av->format_context, AV_LOG_WARNING,
+             "Multiple audio streams request different preferred decoders; "
+             "using %s for stream probing.\n", audio_codec_override->name);
     av->format_context->audio_codec = audio_codec_override;
-  if (!video_conflict)
+  }
+
+  if (video_codec_override) {
+    if (video_conflict)
+      av_log(av->format_context, AV_LOG_WARNING,
+             "Multiple video streams request different preferred decoders; "
+             "using %s for stream probing.\n", video_codec_override->name);
     av->format_context->video_codec = video_codec_override;
-  if (!subtitle_conflict)
+  }
+
+  if (subtitle_codec_override) {
+    if (subtitle_conflict)
+      av_log(av->format_context, AV_LOG_WARNING,
+             "Multiple subtitle streams request different preferred decoders; "
+             "using %s for stream probing.\n", subtitle_codec_override->name);
     av->format_context->subtitle_codec = subtitle_codec_override;
+  }
 
   caml_release_runtime_system();
   err = avformat_find_stream_info(av->format_context, stream_opts);

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -51,6 +51,7 @@ typedef struct {
 typedef struct av_t {
   AVFormatContext *format_context;
   stream_t **streams;
+  const AVCodec **stream_decoders;
   value control_message_callback;
   int is_input;
   value interrupt_cb;
@@ -125,6 +126,8 @@ static void close_av(av_t *av) {
       av_free(av->streams);
       av->streams = NULL;
     }
+
+    av_freep(&av->stream_decoders);
 
     if (av->format_context->iformat) {
       avformat_close_input(&av->format_context);
@@ -650,9 +653,9 @@ CAMLprim value ocaml_av_get_input_format(value _av) {
   CAMLreturn(ret);
 }
 
-static av_t *open_input(char *url, avioformat_const AVInputFormat *format,
-                        AVFormatContext *format_context, value _interrupt,
-                        AVDictionary **options) {
+static av_t *open_av(char *url, avioformat_const AVInputFormat *format,
+                     AVFormatContext *format_context, value _interrupt,
+                     AVDictionary **options) {
   int err;
   av_t *av = NULL;
 
@@ -677,6 +680,7 @@ static av_t *open_input(char *url, avioformat_const AVInputFormat *format,
   av->is_input = 1;
   av->pending_stream_idx = -1;
   av->streams = NULL;
+  av->stream_decoders = NULL;
 
   av->packet = av_packet_alloc();
   if (!av->packet) {
@@ -705,14 +709,6 @@ static av_t *open_input(char *url, avioformat_const AVInputFormat *format,
   if (err < 0)
     goto fail;
 
-  // retrieve stream information
-  caml_release_runtime_system();
-  err = avformat_find_stream_info(av->format_context, NULL);
-  caml_acquire_runtime_system();
-
-  if (err < 0)
-    goto fail;
-
   return av;
 
 fail:
@@ -729,18 +725,41 @@ fail:
   return NULL;
 }
 
+static av_t *open_input(char *url, avioformat_const AVInputFormat *format,
+                        AVFormatContext *format_context, value _interrupt,
+                        AVDictionary **options) {
+  av_t *av = open_av(url, format, format_context, _interrupt, options);
+
+  caml_release_runtime_system();
+  int err = avformat_find_stream_info(av->format_context, NULL);
+  caml_acquire_runtime_system();
+
+  if (err < 0) {
+    close_av(av);
+    av_free(av);
+    ocaml_avutil_raise_error(err);
+    return NULL;
+  }
+
+  return av;
+}
+
 CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
-                                   value _opts) {
-  CAMLparam4(_url, _format, _interrupt, _opts);
-  CAMLlocal3(ret, ans, unused);
+                                   value _opts, value _configure_audio_stream,
+                                   value _configure_video_stream,
+                                   value _configure_subtitle_stream) {
+  CAMLparam5(_url, _format, _interrupt, _opts, _configure_audio_stream);
+  CAMLxparam2(_configure_video_stream, _configure_subtitle_stream);
+  CAMLlocal5(ret, ans, unused, _params, _config);
+  CAMLlocal2(_codec_opt, _configure);
   char *url = NULL;
   avioformat_const AVInputFormat *format = NULL;
   int ulen = caml_string_length(_url);
   AVDictionary *options = NULL;
   char *key, *val;
-  int len = Wosize_val(_opts);
   int i, err, count;
 
+  int len = Wosize_val(_opts);
   for (i = 0; i < len; i++) {
     // Dictionaries copy key/values by default!
     key = (char *)Bytes_val(Field(Field(_opts, i), 0));
@@ -763,25 +782,79 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
     Fail("At least one format or url must be provided!");
   }
 
-  // open input url
-  av_t *av = open_input(url, format, NULL, _interrupt, &options);
+  av_t *av = open_av(url, format, NULL, _interrupt, &options);
 
   if (url)
     av_free(url);
 
-  // Return unused keys
-  count = av_dict_count(options);
+  // Configure per-stream decoders and build opts for
+  // avformat_find_stream_info
+  int nb_streams = av->format_context->nb_streams;
+  av->stream_decoders = av_calloc(nb_streams, sizeof(const AVCodec *));
+  AVDictionary **stream_opts = av_calloc(nb_streams, sizeof(AVDictionary *));
 
+  for (i = 0; i < nb_streams; i++) {
+    AVStream *stream = av->format_context->streams[i];
+    AVCodecParameters *par = stream->codecpar;
+
+    switch (par->codec_type) {
+    case AVMEDIA_TYPE_AUDIO:
+      _configure = _configure_audio_stream;
+      break;
+    case AVMEDIA_TYPE_VIDEO:
+      _configure = _configure_video_stream;
+      break;
+    case AVMEDIA_TYPE_SUBTITLE:
+      _configure = _configure_subtitle_stream;
+      break;
+    default:
+      _configure = Val_none;
+      break;
+    }
+
+    if (_configure == Val_none)
+      continue;
+
+    value_of_codec_parameters_copy(par, &_params);
+    _config = caml_callback(Some_val(_configure), _params);
+
+    _codec_opt = Field(_config, 0);
+    if (_codec_opt != Val_none)
+      av->stream_decoders[i] = AvCodec_val(Some_val(_codec_opt));
+
+    value _stream_opts = Field(_config, 1);
+    int stream_opts_len = Wosize_val(_stream_opts);
+    for (int j = 0; j < stream_opts_len; j++) {
+      value _pair = Field(_stream_opts, j);
+      av_dict_set(&stream_opts[i], String_val(Field(_pair, 0)),
+                  String_val(Field(_pair, 1)), 0);
+    }
+  }
+
+  caml_release_runtime_system();
+  err = avformat_find_stream_info(av->format_context, stream_opts);
+  caml_acquire_runtime_system();
+
+  for (i = 0; i < nb_streams; i++)
+    av_dict_free(&stream_opts[i]);
+  av_freep(&stream_opts);
+
+  if (err < 0) {
+    close_av(av);
+    av_free(av);
+    ocaml_avutil_raise_error(err);
+  }
+
+  // Return unused format-level keys
+  count = av_dict_count(options);
   unused = caml_alloc_tuple(count);
   AVDictionaryEntry *entry = NULL;
   for (i = 0; i < count; i++) {
     entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
     Store_field(unused, i, caml_copy_string(entry->key));
   }
-
   av_dict_free(&options);
 
-  // allocate format context
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
   Av_base_val(ans) = av;
 
@@ -790,6 +863,12 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
   Store_field(ret, 1, unused);
 
   CAMLreturn(ret);
+}
+
+CAMLprim value ocaml_av_open_input_bytecode(value *argv,
+                                            int argc __attribute__((unused))) {
+  return ocaml_av_open_input(argv[0], argv[1], argv[2], argv[3], argv[4],
+                             argv[5], argv[6]);
 }
 
 CAMLprim value ocaml_av_open_input_stream(value _avio, value _format,
@@ -975,6 +1054,8 @@ static stream_t *open_stream_index(av_t *av, int index, const AVCodec *dec) {
 
   // find decoder for the stream
   AVCodecParameters *dec_param = av->format_context->streams[index]->codecpar;
+  if (!dec && av->stream_decoders)
+    dec = av->stream_decoders[index];
   if (!dec) {
     caml_release_runtime_system();
     dec = avcodec_find_decoder(dec_param->codec_id);
@@ -1131,7 +1212,7 @@ static int read_packet(av_t *av) {
 CAMLprim value ocaml_av_read_input(value _unhandled_packet, value _packet,
                                    value _frame, value _av) {
   CAMLparam4(_unhandled_packet, _packet, _frame, _av);
-  CAMLlocal5(ans, decoded_content, frame_value, packet_value, _dec);
+  CAMLlocal4(ans, decoded_content, frame_value, packet_value);
   av_t *av = Av_val(_av);
   AVFrame *frame;
   AVSubtitle *subtitle;
@@ -1187,20 +1268,12 @@ CAMLprim value ocaml_av_read_input(value _unhandled_packet, value _packet,
         }
 
       for (i = 0; i < Wosize_val(_frame) && !stream; i++) {
-        if (Int_val(Field(Field(_frame, i), 0)) == av->packet->stream_index) {
+        if (Int_val(Field(_frame, i)) == av->packet->stream_index) {
           packet = av->packet;
           stream = streams[av->packet->stream_index];
 
-          if (stream == NULL) {
-            const AVCodec *dec = NULL;
-            _dec = Field(Field(_frame, i), 1);
-
-            if (_dec != Val_none) {
-              dec = AvCodec_val(Some_val(_dec));
-            }
-
-            stream = open_stream_index(av, av->packet->stream_index, dec);
-          }
+          if (stream == NULL)
+            stream = open_stream_index(av, av->packet->stream_index, NULL);
         }
       }
 

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -793,6 +793,14 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
   av->stream_decoders = av_calloc(nb_streams, sizeof(const AVCodec *));
   AVDictionary **stream_opts = av_calloc(nb_streams, sizeof(AVDictionary *));
 
+  // Track format-level codec overrides for avformat_find_stream_info.
+  // Only set them if all streams of a given type agree on the same codec;
+  // conflicting preferences cancel each other out to avoid misdetection.
+  const AVCodec *audio_codec_override = NULL;
+  const AVCodec *video_codec_override = NULL;
+  const AVCodec *subtitle_codec_override = NULL;
+  int audio_conflict = 0, video_conflict = 0, subtitle_conflict = 0;
+
   for (i = 0; i < nb_streams; i++) {
     AVStream *stream = av->format_context->streams[i];
     AVCodecParameters *par = stream->codecpar;
@@ -824,13 +832,28 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
       av->stream_decoders[i] = codec;
       switch (par->codec_type) {
       case AVMEDIA_TYPE_AUDIO:
-        av->format_context->audio_codec = codec;
+        if (!audio_conflict) {
+          if (audio_codec_override == NULL)
+            audio_codec_override = codec;
+          else if (audio_codec_override != codec)
+            audio_conflict = 1;
+        }
         break;
       case AVMEDIA_TYPE_VIDEO:
-        av->format_context->video_codec = codec;
+        if (!video_conflict) {
+          if (video_codec_override == NULL)
+            video_codec_override = codec;
+          else if (video_codec_override != codec)
+            video_conflict = 1;
+        }
         break;
       case AVMEDIA_TYPE_SUBTITLE:
-        av->format_context->subtitle_codec = codec;
+        if (!subtitle_conflict) {
+          if (subtitle_codec_override == NULL)
+            subtitle_codec_override = codec;
+          else if (subtitle_codec_override != codec)
+            subtitle_conflict = 1;
+        }
         break;
       default:
         break;
@@ -845,6 +868,13 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
                   String_val(Field(_pair, 1)), 0);
     }
   }
+
+  if (!audio_conflict)
+    av->format_context->audio_codec = audio_codec_override;
+  if (!video_conflict)
+    av->format_context->video_codec = video_codec_override;
+  if (!subtitle_conflict)
+    av->format_context->subtitle_codec = subtitle_codec_override;
 
   caml_release_runtime_system();
   err = avformat_find_stream_info(av->format_context, stream_opts);

--- a/av/av_stubs.c
+++ b/av/av_stubs.c
@@ -819,8 +819,23 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
     _config = caml_callback(Some_val(_configure), _params);
 
     _codec_opt = Field(_config, 0);
-    if (_codec_opt != Val_none)
-      av->stream_decoders[i] = AvCodec_val(Some_val(_codec_opt));
+    if (_codec_opt != Val_none) {
+      const AVCodec *codec = AvCodec_val(Some_val(_codec_opt));
+      av->stream_decoders[i] = codec;
+      switch (par->codec_type) {
+      case AVMEDIA_TYPE_AUDIO:
+        av->format_context->audio_codec = codec;
+        break;
+      case AVMEDIA_TYPE_VIDEO:
+        av->format_context->video_codec = codec;
+        break;
+      case AVMEDIA_TYPE_SUBTITLE:
+        av->format_context->subtitle_codec = codec;
+        break;
+      default:
+        break;
+      }
+    }
 
     value _stream_opts = Field(_config, 1);
     int stream_opts_len = Wosize_val(_stream_opts);
@@ -834,6 +849,10 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
   caml_release_runtime_system();
   err = avformat_find_stream_info(av->format_context, stream_opts);
   caml_acquire_runtime_system();
+
+  av->format_context->audio_codec = NULL;
+  av->format_context->video_codec = NULL;
+  av->format_context->subtitle_codec = NULL;
 
   for (i = 0; i < nb_streams; i++)
     av_dict_free(&stream_opts[i]);

--- a/avfilter/avfilter.mli
+++ b/avfilter/avfilter.mli
@@ -58,9 +58,9 @@ val sample_rate : [ `Audio ] context -> int
 val sample_format : [ `Audio ] context -> Avutil.Sample_format.t
 val set_frame_size : [ `Audio ] context -> int -> unit
 
-(** Get the separator character used for array-type options of a filter.
-    Raises [Failure] if the option does not exist or does not support arrays
-    (e.g. on FFmpeg < 7). *)
+(** Get the separator character used for array-type options of a filter. Raises
+    [Failure] if the option does not exist or does not support arrays (e.g. on
+    FFmpeg < 7). *)
 val get_array_separator : filter_name:string -> option_name:string -> char
 
 exception Exists

--- a/avutil/avutil.ml
+++ b/avutil/avutil.ml
@@ -14,13 +14,12 @@ type media_type = Media_types.t
 
 (* Format *)
 type ('line, 'media) format
-
 type version = { major : int; minor : int; micro : int }
 
 external version : unit -> int = "ocaml_avutil_version" [@@noalloc]
 
 external version_int : int -> int -> int -> int = "ocaml_avutil_version_int"
-  [@@noalloc]
+[@@noalloc]
 
 let version =
   let v = version () in

--- a/examples/aresample.ml
+++ b/examples/aresample.ml
@@ -50,13 +50,13 @@ let () =
         match
           Avfilter.get_array_separator ~filter_name:"aformat" ~option_name:name
         with
-        | _ -> `Pair (name, `Array (List.map (fun s -> `String s) values))
-        | exception _ -> `Pair (name, `String (String.concat "|" values))
+          | _ -> `Pair (name, `Array (List.map (fun s -> `String s) values))
+          | exception _ -> `Pair (name, `String (String.concat "|" values))
       in
       let args =
         [
-          aformat_arg "sample_fmts" [ "s16"; "fltp" ];
-          aformat_arg "channel_layouts" [ "stereo"; "mono" ];
+          aformat_arg "sample_fmts" ["s16"; "fltp"];
+          aformat_arg "channel_layouts" ["stereo"; "mono"];
         ]
       in
       Avfilter.attach ~args ~name:"aformat" aformat_filter config

--- a/examples/dune
+++ b/examples/dune
@@ -137,3 +137,8 @@
  (name bitmap_subtitle_to_jpeg)
  (modules bitmap_subtitle_to_jpeg)
  (libraries ffmpeg-av ffmpeg-swscale))
+
+(executable
+ (name reenc_vp9)
+ (modules reenc_vp9)
+ (libraries ffmpeg-av))

--- a/examples/reenc_vp9.ml
+++ b/examples/reenc_vp9.ml
@@ -1,0 +1,63 @@
+let () = Printexc.record_backtrace true
+
+let () =
+  if Array.length Sys.argv < 3 then (
+    Printf.printf "usage: %s input_file output_file\n" Sys.argv.(0);
+    exit 1);
+
+  Avutil.Log.set_level `Info;
+  Avutil.Log.set_callback print_string;
+
+  let decoder = Avcodec.Video.find_decoder_by_name "libvpx-vp9" in
+  let encoder = Avcodec.Video.find_encoder_by_name "libvpx-vp9" in
+
+  let configure_video_stream _params =
+    { Av.codec = Some decoder; opts = None }
+  in
+
+  let src =
+    Av.open_input ~configure_video_stream Sys.argv.(1)
+  in
+
+  let ivss = Av.get_video_streams src in
+
+  let dst = Av.open_output Sys.argv.(2) in
+
+  let ovss =
+    List.map
+      (fun (i, _, params) ->
+        let width = Avcodec.Video.get_width params in
+        let height = Avcodec.Video.get_height params in
+        let pixel_format =
+          match Avcodec.Video.get_pixel_format params with
+            | None -> failwith "Pixel format unknown!"
+            | Some f -> f
+        in
+        Printf.printf "Stream %d: %dx%d pixel_format=%s\n%!" i width height
+          (match Avutil.Pixel_format.to_string pixel_format with
+            | Some s -> s
+            | None -> "unknown");
+        let time_base = Av.get_time_base (let _, s, _ = List.nth ivss 0 in s) in
+        ( i,
+          Av.new_video_stream ~pixel_format ~width ~height ~time_base
+            ~codec:encoder dst ))
+      ivss
+  in
+
+  let rec loop () =
+    match
+      Av.read_input ~video_frame:(List.map (fun (_, s, _) -> s) ivss) src
+    with
+      | `Video_frame (i, frame) ->
+          Av.write_frame (List.assoc i ovss) frame;
+          loop ()
+      | exception Avutil.Error `Eof -> ()
+      | _ -> assert false
+  in
+  loop ();
+
+  Av.close src;
+  Av.close dst;
+
+  Gc.full_major ();
+  Gc.full_major ()

--- a/swresample/swresample.ml
+++ b/swresample/swresample.ml
@@ -6,6 +6,7 @@ external version : unit -> int = "ocaml_swresample_version" [@@noalloc]
 let version =
   let v = version () in
   { major = v lsr 16; minor = (v lsr 8) land 0xff; micro = v land 0xff }
+
 module SF = Avutil.Sample_format
 module CL = Avutil.Channel_layout
 


### PR DESCRIPTION
Add per-stream decoder configuration callbacks to `Av.open_input`. This allows callers to specify a preferred decoder (and optional per-stream options) for each stream before `avformat_find_stream_info` is called, which is necessary to correctly detect codec parameters that depend on the decoder — most notably pixel formats like `yuva420p` for VP9 streams with an alpha channel, which the default VP9 decoder reports as `yuv420p`.

## What changed

**New API**: `open_input` now accepts three optional callbacks — `configure_audio_stream`, `configure_video_stream`, `configure_subtitle_stream` — each receiving the stream's `Avcodec.params` and returning a `stream_config` with an optional preferred codec and optional per-stream options.

**Stream probing**: The preferred codec is set on `format_context->video_codec` (and audio/subtitle equivalents) before calling `avformat_find_stream_info`, then cleared immediately after. This causes FFmpeg's `find_probe_decoder` to use the preferred codec during stream analysis, giving accurate codec parameters. If multiple streams of the same type request _different_ preferred codecs, the first one is used and a warning is emitted via `av_log`.

**Decoding**: The preferred codec is also stored in a new `stream_decoders` array on `av_t`, which `open_stream_index` consults as a fallback when opening a stream for frame decoding.

**Cleanup**: `Av.set_decoder` and the `decoder` field on the `stream` record type have been removed — decoder configuration now happens entirely through the configure callbacks at open time. The `read_input` frame array was simplified from `(int * codec_option) array` to `int array` accordingly.
